### PR TITLE
fix: add artifact-metadata:write permission for attestations

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `artifact-metadata: write` to workflow permissions
- Required by upstream `NethermindEth/github-workflows` v2.0.0 for `actions/attest-build-provenance`

## Context
https://github.blog/changelog/2026-01-13-new-fine-grained-permission-for-artifact-metadata-is-now-generally-available/