### PR TITLE
feat: high-signal comparison output with expected-difference rules

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,14 @@
+# Trivy ignore list for the Docker image scan (see
+# .github/workflows/build_docker_image.yml). Keep this list small and
+# documented, and remove entries as soon as the upstream fix is available.
+
+# CVE-2026-39822 — Go stdlib os.Root symlink-following vulnerability (HIGH).
+# This is a Go toolchain/stdlib issue, not application code. Two Go binaries
+# in the image were flagged:
+#   * app/jsonrpc-bench-runner — our binary. FIXED by rebuilding with a patched
+#     toolchain (runner/Dockerfile now uses golang:1.25.12-alpine).
+#   * usr/bin/k6 — provided by the upstream grafana/k6 base image, compiled
+#     with Go 1.26.4. We cannot recompile it; it will clear once grafana/k6
+#     ships a base image built with Go >= 1.26.5. Remove this entry then (and
+#     consider bumping the grafana/k6 base tag in runner/Dockerfile).
+CVE-2026-39822

--- a/README.md
+++ b/README.md
@@ -245,16 +245,102 @@ go run ./runner compare \
   --output ./comparison-results
 ```
 
-Both artefacts are always produced:
+These artefacts are always produced:
 
 - `<output>/comparison-results.json`
 - `<output>/comparison-report.html`
+- `<output>/comparison-provenance.json` — the effective config (client refs,
+  active rules, block override, output/retry settings, sample counts) so a
+  report is self-describing and reproducible.
 
 A `config/compare/defaults.yaml` ships with the repo and reproduces the
 old baseline of eight common methods (eth_blockNumber, eth_getBalance,
 eth_call, eth_getBlockByNumber, eth_getTransactionCount, eth_chainId,
 eth_gasPrice, net_version) with the parameters the CLI previously used
 implicitly.
+
+#### Declaring expected differences (`comparison:` block)
+
+Cross-client (and cross-version) runs surface many *expected* differences —
+a serialization change like `totalDifficulty`, sub-percent `eth_estimateGas`
+drift, or a namespace that is disabled on one node. Declare these in an
+optional `comparison:` block so they stop flooding the report:
+
+```yaml
+comparison:
+  # Rewrite latest/pending tags to a static block and append a block arg to
+  # calls that omit one, so archive nodes at different heads are comparable.
+  block_override: "0x1406f40"
+  rules:
+    # Treat two hex quantities as equal within abs units OR rel fraction.
+    # (eth_estimateGas already gets a built-in 10% tolerance by default.)
+    - method: eth_estimateGas
+      path: result
+      kind: numeric_tolerance
+      abs: 32
+      rel: 0.10
+    # Drop a path entirely; `[*]` matches any array index.
+    - path: result.totalDifficulty
+      kind: ignore
+    - method: eth_getBlockByNumber
+      path: result.transactions[*].v
+      kind: ignore
+    # Compare only the error code, not the (benign) message wording.
+    - method: eth_call
+      kind: error_code_only    # also: error_presence_only
+```
+
+Rule kinds: `ignore`, `numeric_tolerance` (`abs`/`rel`), `error_code_only`,
+`error_presence_only`. A rule with no `method` applies to all methods; no
+`path` applies to the whole response value. Everything in the block is
+optional and defaults reproduce the prior behavior.
+
+The same block can live in a **standalone file** passed with `--rules`, which
+merges over the config's own rules and works in corpus mode too:
+
+```bash
+go run ./runner compare \
+  --from-jsonl ./rpc-calls --sample 400 \
+  --rules ./config/compare/archive-rules.yaml \
+  --block-override 0x1406f40 \
+  --clients ./config/clients/clients.yaml --client-refs old,new \
+  --diff-only --fail-on-diff --concurrency 4
+```
+
+#### Building a config from a corpus (`--from-jsonl`)
+
+Instead of `--config`, point `--from-jsonl <dir>` at a corpus directory. It
+recurses and reads both line-delimited `*.jsonl` files and `*.json` files
+holding a JSON array of `{method, params}` objects. `--sample N` keeps at
+most N calls per method (deterministic; control the seed with
+`--sample-seed`). Head-dependent and unstorable methods (`eth_getProof`,
+`eth_gasPrice`, `eth_syncing`, `eth_blockNumber`, `eth_maxPriorityFeePerGas`,
+the `debug_` namespace) are excluded; `eth_feeHistory` is kept only when a
+block override pins its `newestBlock`.
+
+#### Smaller reports and CI gating
+
+- `--diff-only` excludes identical calls. To keep the report small it also
+  caps response bodies (`4096` bytes) unless you pass `--keep-response-bodies`
+  to retain them or `--omit-matching-responses` to drop them entirely.
+  `--max-response-bytes N` sets an explicit cap.
+- The run prints a category summary: identical / differ (real) / differ
+  (env/expected) / transport-error / schema-error / skipped, plus per-class
+  environment/capability error counts.
+- `--fail-on-diff` exits non-zero on **real** differences only (environment/
+  capability differences are excluded by default); add `--fail-on-env-diff`
+  for strict mode that also fails on those.
+- `--skip-above-head` queries each client's head and skips calls pinned to a
+  higher block, so a less-synced node does not produce false differences.
+
+#### Robustness against throttling nodes
+
+Transport errors and 5xx responses are retried with exponential backoff.
+`--max-retries` sets the attempt budget (falls back to a client's
+`max_retries` in `clients.yaml`, or 5 if unset) and `--retry-base-delay` the
+base backoff. A call that still fails is recorded per-call and the run
+continues, so a single dead endpoint never discards an otherwise good run.
+Keep `--concurrency` low (≤4) against nodes that throttle connection bursts.
 
 ### OpenRPC-Driven Comparison
 

--- a/config/compare/example.yaml
+++ b/config/compare/example.yaml
@@ -3,6 +3,34 @@ description: >
   Example compare config demonstrating optional per-call ids, multiple
   variants for the same method, and complex parameter objects.
 
+# Optional. Declares differences that are expected (and therefore not real
+# findings), plus a static block to pin latest/pending tags to. Everything
+# here is optional; omit the whole block to reproduce the default behavior.
+comparison:
+  # Rewrite latest/pending block tags to a fixed block and append a block
+  # argument to eth_call/eth_estimateGas/etc. calls that omit one, so archive
+  # nodes at different heads can be compared.
+  # block_override: "0x1406f40"
+  rules:
+    # eth_estimateGas drifts by a few gas units between versions; treat two
+    # quantities as equal when within `abs` units OR `rel` fraction of each
+    # other. (eth_estimateGas already gets a built-in 10% tolerance by default.)
+    - method: eth_estimateGas
+      path: result
+      kind: numeric_tolerance
+      abs: 32
+      rel: 0.10
+    # totalDifficulty is a known serialization difference between clients.
+    - path: result.totalDifficulty
+      kind: ignore
+    # Array wildcards: ignore a field on every transaction in the block.
+    - method: eth_getBlockByNumber
+      path: result.transactions[*].v
+      kind: ignore
+    # Compare only the error code, not the (benign) message wording.
+    - method: eth_call
+      kind: error_code_only
+
 calls:
   eth_blockNumber:
     - params: []

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for Go runner
-FROM golang:1.25.11-alpine AS builder
+FROM golang:1.25.12-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/runner/cmd/compare.go
+++ b/runner/cmd/compare.go
@@ -20,12 +20,15 @@ var (
 	compareConcurrency    int
 	compareTimeout        int
 
+	compareRulesPath        string
 	compareDiffOnly         bool
+	compareKeepBodies       bool
 	compareOmitMatching     bool
 	compareMaxResponseBytes int
 	compareMaxRetries       int
 	compareRetryBaseDelay   time.Duration
 	compareFailOnDiff       bool
+	compareFailOnEnv        bool
 	compareSkipAboveHead    bool
 	compareBlockOverride    string
 	compareFromJSONL        string
@@ -47,15 +50,18 @@ func init() {
 	compareCmd.Flags().IntVar(&compareConcurrency, "concurrency", 5, "Concurrent requests")
 	compareCmd.Flags().IntVar(&compareTimeout, "timeout", 30, "Per-request timeout in seconds")
 
-	compareCmd.Flags().BoolVar(&compareDiffOnly, "diff-only", false, "Exclude identical calls from the output")
+	compareCmd.Flags().StringVar(&compareRulesPath, "rules", "", "Path to a YAML file with a comparison: block (rules + block_override) to merge in; works with --config and --from-jsonl")
+	compareCmd.Flags().BoolVar(&compareDiffOnly, "diff-only", false, "Exclude identical calls from the output (caps response bodies unless --keep-response-bodies)")
+	compareCmd.Flags().BoolVar(&compareKeepBodies, "keep-response-bodies", false, "With --diff-only, keep full response bodies instead of truncating them")
 	compareCmd.Flags().BoolVar(&compareOmitMatching, "omit-matching-responses", false, "Drop full responses; keep only diff entries")
 	compareCmd.Flags().IntVar(&compareMaxResponseBytes, "max-response-bytes", 0, "Truncate embedded response bodies larger than N bytes (0 = no limit)")
-	compareCmd.Flags().IntVar(&compareMaxRetries, "max-retries", 0, "Max transport attempts (0 = per-client max_retries, else 5)")
+	compareCmd.Flags().IntVar(&compareMaxRetries, "max-retries", 0, "Max transport attempts per request (0 = use the client's max_retries from clients.yaml, or 5 if unset)")
 	compareCmd.Flags().DurationVar(&compareRetryBaseDelay, "retry-base-delay", 0, "Base backoff between transport retries (0 = 200ms)")
-	compareCmd.Flags().BoolVar(&compareFailOnDiff, "fail-on-diff", false, "Exit non-zero when post-filter differences remain")
+	compareCmd.Flags().BoolVar(&compareFailOnDiff, "fail-on-diff", false, "Exit non-zero when real (non-environment) differences remain")
+	compareCmd.Flags().BoolVar(&compareFailOnEnv, "fail-on-env-diff", false, "Also exit non-zero on environment/capability differences (compose with --fail-on-diff for strict mode)")
 	compareCmd.Flags().BoolVar(&compareSkipAboveHead, "skip-above-head", false, "Skip calls pinned to a block above the lowest client head")
-	compareCmd.Flags().StringVar(&compareBlockOverride, "block-override", "", "Rewrite latest/pending block tags to this static block (overrides the config)")
-	compareCmd.Flags().StringVar(&compareFromJSONL, "from-jsonl", "", "Build the config from rpc-calls/*.jsonl in this directory instead of --config")
+	compareCmd.Flags().StringVar(&compareBlockOverride, "block-override", "", "Rewrite latest/pending block tags to this static block (overrides config and --rules)")
+	compareCmd.Flags().StringVar(&compareFromJSONL, "from-jsonl", "", "Build the config from a corpus directory (recurses; reads *.jsonl and *.json arrays) instead of --config")
 	compareCmd.Flags().IntVar(&compareSample, "sample", 0, "With --from-jsonl, sample at most N calls per method (0 = all)")
 	compareCmd.Flags().Int64Var(&compareSampleSeed, "sample-seed", 42, "Deterministic seed for --sample")
 
@@ -89,9 +95,28 @@ func runCompare(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("exactly one of --config or --from-jsonl is required")
 	}
 
+	// Load the optional --rules file first so its block_override can inform
+	// corpus loading (e.g. keeping pinnable methods like eth_feeHistory).
+	var fileRules []comparator.ComparisonRule
+	var fileBlockOverride string
+	if compareRulesPath != "" {
+		fileRules, fileBlockOverride, err = comparator.LoadComparisonRules(compareRulesPath)
+		if err != nil {
+			return fmt.Errorf("failed to load rules file: %w", err)
+		}
+	}
+
+	// Effective block override, highest precedence first: --block-override flag,
+	// then the --rules file. (A --config file's own block_override applies in
+	// config mode and is layered below both.)
+	effectiveBlockOverride := fileBlockOverride
+	if compareBlockOverride != "" {
+		effectiveBlockOverride = compareBlockOverride
+	}
+
 	var cfg *comparator.ComparisonConfig
 	if compareFromJSONL != "" {
-		cfg, err = comparator.LoadCorpusConfig(compareFromJSONL, compareSample, compareSampleSeed)
+		cfg, err = comparator.LoadCorpusConfig(compareFromJSONL, compareSample, compareSampleSeed, effectiveBlockOverride)
 		if err != nil {
 			return fmt.Errorf("failed to build config from corpus: %w", err)
 		}
@@ -113,9 +138,18 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	cfg.MaxRetries = compareMaxRetries
 	cfg.RetryBaseDelayMs = int(compareRetryBaseDelay.Milliseconds())
 	cfg.SkipAboveHead = compareSkipAboveHead
+
+	// Layer the --rules file on top of any rules from --config, then apply the
+	// block-override precedence (rules file over config, flag over everything).
+	cfg.MergeComparisonRules(fileRules)
+	if fileBlockOverride != "" {
+		cfg.BlockOverride = fileBlockOverride
+	}
 	if compareBlockOverride != "" {
 		cfg.BlockOverride = compareBlockOverride
 	}
+
+	applyDiffOnlyDefaults(cfg, compareKeepBodies)
 
 	comp, err := comparator.NewComparator(cfg)
 	if err != nil {
@@ -128,13 +162,23 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	}
 	logger.Infof("Completed comparison of %d calls", len(results))
 
-	return finishComparison(comp, compareFailOnDiff)
+	return finishComparison(comp, compareFailOnDiff, compareFailOnEnv)
+}
+
+// applyDiffOnlyDefaults makes --diff-only the obvious "small report" switch: if
+// no body-trimming flag was given (and bodies weren't explicitly kept), it caps
+// response bodies so the report doesn't balloon on large differing responses.
+func applyDiffOnlyDefaults(cfg *comparator.ComparisonConfig, keepBodies bool) {
+	if cfg.DiffOnly && !keepBodies && !cfg.OmitMatchingResponses && cfg.MaxResponseBytes <= 0 {
+		cfg.MaxResponseBytes = comparator.DefaultDiffOnlyMaxResponseBytes
+		logger.Warnf("--diff-only without a body-trimming flag: truncating response bodies to %d bytes to keep the report small; pass --keep-response-bodies to retain them or --omit-matching-responses to drop them entirely", comparator.DefaultDiffOnlyMaxResponseBytes)
+	}
 }
 
 // finishComparison writes the results, provenance sidecar, and HTML report,
 // prints the outcome summary, and returns a non-zero (error) result when
 // failOnDiff is set and post-filter differences remain.
-func finishComparison(comp *comparator.Comparator, failOnDiff bool) error {
+func finishComparison(comp *comparator.Comparator, failOnDiff, failOnEnv bool) error {
 	jsonPath := filepath.Join(outputDir, "comparison-results.json")
 	if err := comp.SaveResults(jsonPath); err != nil {
 		return fmt.Errorf("failed to save comparison results: %w", err)
@@ -154,16 +198,21 @@ func finishComparison(comp *comparator.Comparator, failOnDiff bool) error {
 
 	printComparisonSummary(comp.Summarize())
 
-	if failOnDiff && comp.HasDifferences() {
-		return fmt.Errorf("differences found (--fail-on-diff)")
+	realFail := failOnDiff && comp.HasRealDifferences()
+	envFail := failOnEnv && comp.HasEnvDifferences()
+	if realFail {
+		return fmt.Errorf("real differences found (--fail-on-diff)")
+	}
+	if envFail {
+		return fmt.Errorf("environment/expected differences found (--fail-on-env-diff)")
 	}
 	return nil
 }
 
 // printComparisonSummary logs a one-screen tally of the run's outcomes.
 func printComparisonSummary(s comparator.Summary) {
-	logger.Infof("Summary: %d calls — %d identical, %d differ, %d transport-error, %d schema-error, %d skipped",
-		s.Total, s.Identical, s.Differ, s.TransportError, s.SchemaError, s.Skipped)
+	logger.Infof("Summary: %d calls — %d identical, %d differ (real), %d differ (env/expected), %d transport-error, %d schema-error, %d skipped",
+		s.Total, s.Identical, s.Differ, s.DifferEnv, s.TransportError, s.SchemaError, s.Skipped)
 	for class, n := range s.EnvError {
 		logger.Infof("  env/capability errors [%s]: %d", class, n)
 	}

--- a/runner/cmd/compare.go
+++ b/runner/cmd/compare.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,6 +19,18 @@ var (
 	compareValidateSchema bool
 	compareConcurrency    int
 	compareTimeout        int
+
+	compareDiffOnly         bool
+	compareOmitMatching     bool
+	compareMaxResponseBytes int
+	compareMaxRetries       int
+	compareRetryBaseDelay   time.Duration
+	compareFailOnDiff       bool
+	compareSkipAboveHead    bool
+	compareBlockOverride    string
+	compareFromJSONL        string
+	compareSample           int
+	compareSampleSeed       int64
 )
 
 var compareCmd = &cobra.Command{
@@ -33,7 +46,19 @@ func init() {
 	compareCmd.Flags().BoolVar(&compareValidateSchema, "validate-schema", false, "Validate responses against the OpenRPC schema")
 	compareCmd.Flags().IntVar(&compareConcurrency, "concurrency", 5, "Concurrent requests")
 	compareCmd.Flags().IntVar(&compareTimeout, "timeout", 30, "Per-request timeout in seconds")
-	_ = compareCmd.MarkFlagRequired("config")
+
+	compareCmd.Flags().BoolVar(&compareDiffOnly, "diff-only", false, "Exclude identical calls from the output")
+	compareCmd.Flags().BoolVar(&compareOmitMatching, "omit-matching-responses", false, "Drop full responses; keep only diff entries")
+	compareCmd.Flags().IntVar(&compareMaxResponseBytes, "max-response-bytes", 0, "Truncate embedded response bodies larger than N bytes (0 = no limit)")
+	compareCmd.Flags().IntVar(&compareMaxRetries, "max-retries", 0, "Max transport attempts (0 = per-client max_retries, else 5)")
+	compareCmd.Flags().DurationVar(&compareRetryBaseDelay, "retry-base-delay", 0, "Base backoff between transport retries (0 = 200ms)")
+	compareCmd.Flags().BoolVar(&compareFailOnDiff, "fail-on-diff", false, "Exit non-zero when post-filter differences remain")
+	compareCmd.Flags().BoolVar(&compareSkipAboveHead, "skip-above-head", false, "Skip calls pinned to a block above the lowest client head")
+	compareCmd.Flags().StringVar(&compareBlockOverride, "block-override", "", "Rewrite latest/pending block tags to this static block (overrides the config)")
+	compareCmd.Flags().StringVar(&compareFromJSONL, "from-jsonl", "", "Build the config from rpc-calls/*.jsonl in this directory instead of --config")
+	compareCmd.Flags().IntVar(&compareSample, "sample", 0, "With --from-jsonl, sample at most N calls per method (0 = all)")
+	compareCmd.Flags().Int64Var(&compareSampleSeed, "sample-seed", 42, "Deterministic seed for --sample")
+
 	_ = compareCmd.MarkFlagRequired("clients")
 	_ = compareCmd.MarkFlagRequired("client-refs")
 }
@@ -60,9 +85,21 @@ func runCompare(cmd *cobra.Command, args []string) error {
 		clients = append(clients, client)
 	}
 
-	cfg, err := comparator.LoadCompareConfig(compareConfigPath)
-	if err != nil {
-		return fmt.Errorf("failed to load compare config: %w", err)
+	if (compareConfigPath == "") == (compareFromJSONL == "") {
+		return fmt.Errorf("exactly one of --config or --from-jsonl is required")
+	}
+
+	var cfg *comparator.ComparisonConfig
+	if compareFromJSONL != "" {
+		cfg, err = comparator.LoadCorpusConfig(compareFromJSONL, compareSample, compareSampleSeed)
+		if err != nil {
+			return fmt.Errorf("failed to build config from corpus: %w", err)
+		}
+	} else {
+		cfg, err = comparator.LoadCompareConfig(compareConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to load compare config: %w", err)
+		}
 	}
 
 	cfg.Clients = clients
@@ -70,6 +107,15 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	cfg.Concurrency = compareConcurrency
 	cfg.TimeoutSeconds = compareTimeout
 	cfg.OutputDir = outputDir
+	cfg.DiffOnly = compareDiffOnly
+	cfg.OmitMatchingResponses = compareOmitMatching
+	cfg.MaxResponseBytes = compareMaxResponseBytes
+	cfg.MaxRetries = compareMaxRetries
+	cfg.RetryBaseDelayMs = int(compareRetryBaseDelay.Milliseconds())
+	cfg.SkipAboveHead = compareSkipAboveHead
+	if compareBlockOverride != "" {
+		cfg.BlockOverride = compareBlockOverride
+	}
 
 	comp, err := comparator.NewComparator(cfg)
 	if err != nil {
@@ -82,11 +128,23 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	}
 	logger.Infof("Completed comparison of %d calls", len(results))
 
+	return finishComparison(comp, compareFailOnDiff)
+}
+
+// finishComparison writes the results, provenance sidecar, and HTML report,
+// prints the outcome summary, and returns a non-zero (error) result when
+// failOnDiff is set and post-filter differences remain.
+func finishComparison(comp *comparator.Comparator, failOnDiff bool) error {
 	jsonPath := filepath.Join(outputDir, "comparison-results.json")
 	if err := comp.SaveResults(jsonPath); err != nil {
 		return fmt.Errorf("failed to save comparison results: %w", err)
 	}
 	logger.Infof("Comparison results saved to %s", jsonPath)
+
+	provPath := filepath.Join(outputDir, "comparison-provenance.json")
+	if err := comp.SaveProvenance(provPath); err != nil {
+		return fmt.Errorf("failed to save comparison provenance: %w", err)
+	}
 
 	htmlPath := filepath.Join(outputDir, "comparison-report.html")
 	if err := comp.GenerateHTMLReport(htmlPath); err != nil {
@@ -94,7 +152,21 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	}
 	logger.Infof("Comparison HTML report generated at %s", htmlPath)
 
+	printComparisonSummary(comp.Summarize())
+
+	if failOnDiff && comp.HasDifferences() {
+		return fmt.Errorf("differences found (--fail-on-diff)")
+	}
 	return nil
+}
+
+// printComparisonSummary logs a one-screen tally of the run's outcomes.
+func printComparisonSummary(s comparator.Summary) {
+	logger.Infof("Summary: %d calls — %d identical, %d differ, %d transport-error, %d schema-error, %d skipped",
+		s.Total, s.Identical, s.Differ, s.TransportError, s.SchemaError, s.Skipped)
+	for class, n := range s.EnvError {
+		logger.Infof("  env/capability errors [%s]: %d", class, n)
+	}
 }
 
 func splitCSV(s string) []string {

--- a/runner/cmd/compare_openrpc.go
+++ b/runner/cmd/compare_openrpc.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -20,6 +20,14 @@ var (
 	openrpcValidateSchema bool
 	openrpcConcurrency    int
 	openrpcTimeout        int
+
+	openrpcDiffOnly         bool
+	openrpcOmitMatching     bool
+	openrpcMaxResponseBytes int
+	openrpcMaxRetries       int
+	openrpcRetryBaseDelay   time.Duration
+	openrpcFailOnDiff       bool
+	openrpcSkipAboveHead    bool
 )
 
 var compareOpenRPCCmd = &cobra.Command{
@@ -38,6 +46,15 @@ func init() {
 	compareOpenRPCCmd.Flags().BoolVar(&openrpcValidateSchema, "validate-schema", false, "Validate responses against the OpenRPC schema")
 	compareOpenRPCCmd.Flags().IntVar(&openrpcConcurrency, "concurrency", 5, "Concurrent requests")
 	compareOpenRPCCmd.Flags().IntVar(&openrpcTimeout, "timeout", 30, "Per-request timeout in seconds")
+
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcDiffOnly, "diff-only", false, "Exclude identical calls from the output")
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcOmitMatching, "omit-matching-responses", false, "Drop full responses; keep only diff entries")
+	compareOpenRPCCmd.Flags().IntVar(&openrpcMaxResponseBytes, "max-response-bytes", 0, "Truncate embedded response bodies larger than N bytes (0 = no limit)")
+	compareOpenRPCCmd.Flags().IntVar(&openrpcMaxRetries, "max-retries", 0, "Max transport attempts (0 = per-client max_retries, else 5)")
+	compareOpenRPCCmd.Flags().DurationVar(&openrpcRetryBaseDelay, "retry-base-delay", 0, "Base backoff between transport retries (0 = 200ms)")
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcFailOnDiff, "fail-on-diff", false, "Exit non-zero when post-filter differences remain")
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcSkipAboveHead, "skip-above-head", false, "Skip calls pinned to a block above the lowest client head")
+
 	_ = compareOpenRPCCmd.MarkFlagRequired("spec")
 	_ = compareOpenRPCCmd.MarkFlagRequired("clients")
 	_ = compareOpenRPCCmd.MarkFlagRequired("client-refs")
@@ -81,6 +98,12 @@ func runCompareOpenRPC(cmd *cobra.Command, args []string) error {
 	cfg.TimeoutSeconds = openrpcTimeout
 	cfg.OutputDir = outputDir
 	cfg.Verbose = openrpcCurl
+	cfg.DiffOnly = openrpcDiffOnly
+	cfg.OmitMatchingResponses = openrpcOmitMatching
+	cfg.MaxResponseBytes = openrpcMaxResponseBytes
+	cfg.MaxRetries = openrpcMaxRetries
+	cfg.RetryBaseDelayMs = int(openrpcRetryBaseDelay.Milliseconds())
+	cfg.SkipAboveHead = openrpcSkipAboveHead
 
 	if openrpcFilter != "" {
 		applyMethodFilter(cfg, splitCSV(openrpcFilter))
@@ -99,19 +122,7 @@ func runCompareOpenRPC(cmd *cobra.Command, args []string) error {
 	}
 	logger.Infof("Completed comparison of %d methods", len(results))
 
-	jsonPath := filepath.Join(outputDir, "comparison-results.json")
-	if err := comp.SaveResults(jsonPath); err != nil {
-		return fmt.Errorf("failed to save comparison results: %w", err)
-	}
-	logger.Infof("Comparison results saved to %s", jsonPath)
-
-	htmlPath := filepath.Join(outputDir, "comparison-report.html")
-	if err := comp.GenerateHTMLReport(htmlPath); err != nil {
-		return fmt.Errorf("failed to generate comparison HTML report: %w", err)
-	}
-	logger.Infof("Comparison HTML report generated at %s", htmlPath)
-
-	return nil
+	return finishComparison(comp, openrpcFailOnDiff)
 }
 
 func applyMethodFilter(cfg *comparator.ComparisonConfig, methodsToInclude []string) {

--- a/runner/cmd/compare_openrpc.go
+++ b/runner/cmd/compare_openrpc.go
@@ -22,11 +22,13 @@ var (
 	openrpcTimeout        int
 
 	openrpcDiffOnly         bool
+	openrpcKeepBodies       bool
 	openrpcOmitMatching     bool
 	openrpcMaxResponseBytes int
 	openrpcMaxRetries       int
 	openrpcRetryBaseDelay   time.Duration
 	openrpcFailOnDiff       bool
+	openrpcFailOnEnv        bool
 	openrpcSkipAboveHead    bool
 )
 
@@ -47,12 +49,14 @@ func init() {
 	compareOpenRPCCmd.Flags().IntVar(&openrpcConcurrency, "concurrency", 5, "Concurrent requests")
 	compareOpenRPCCmd.Flags().IntVar(&openrpcTimeout, "timeout", 30, "Per-request timeout in seconds")
 
-	compareOpenRPCCmd.Flags().BoolVar(&openrpcDiffOnly, "diff-only", false, "Exclude identical calls from the output")
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcDiffOnly, "diff-only", false, "Exclude identical calls from the output (caps response bodies unless --keep-response-bodies)")
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcKeepBodies, "keep-response-bodies", false, "With --diff-only, keep full response bodies instead of truncating them")
 	compareOpenRPCCmd.Flags().BoolVar(&openrpcOmitMatching, "omit-matching-responses", false, "Drop full responses; keep only diff entries")
 	compareOpenRPCCmd.Flags().IntVar(&openrpcMaxResponseBytes, "max-response-bytes", 0, "Truncate embedded response bodies larger than N bytes (0 = no limit)")
-	compareOpenRPCCmd.Flags().IntVar(&openrpcMaxRetries, "max-retries", 0, "Max transport attempts (0 = per-client max_retries, else 5)")
+	compareOpenRPCCmd.Flags().IntVar(&openrpcMaxRetries, "max-retries", 0, "Max transport attempts per request (0 = use the client's max_retries from clients.yaml, or 5 if unset)")
 	compareOpenRPCCmd.Flags().DurationVar(&openrpcRetryBaseDelay, "retry-base-delay", 0, "Base backoff between transport retries (0 = 200ms)")
-	compareOpenRPCCmd.Flags().BoolVar(&openrpcFailOnDiff, "fail-on-diff", false, "Exit non-zero when post-filter differences remain")
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcFailOnDiff, "fail-on-diff", false, "Exit non-zero when real (non-environment) differences remain")
+	compareOpenRPCCmd.Flags().BoolVar(&openrpcFailOnEnv, "fail-on-env-diff", false, "Also exit non-zero on environment/capability differences (compose with --fail-on-diff for strict mode)")
 	compareOpenRPCCmd.Flags().BoolVar(&openrpcSkipAboveHead, "skip-above-head", false, "Skip calls pinned to a block above the lowest client head")
 
 	_ = compareOpenRPCCmd.MarkFlagRequired("spec")
@@ -104,6 +108,7 @@ func runCompareOpenRPC(cmd *cobra.Command, args []string) error {
 	cfg.MaxRetries = openrpcMaxRetries
 	cfg.RetryBaseDelayMs = int(openrpcRetryBaseDelay.Milliseconds())
 	cfg.SkipAboveHead = openrpcSkipAboveHead
+	applyDiffOnlyDefaults(cfg, openrpcKeepBodies)
 
 	if openrpcFilter != "" {
 		applyMethodFilter(cfg, splitCSV(openrpcFilter))
@@ -122,7 +127,7 @@ func runCompareOpenRPC(cmd *cobra.Command, args []string) error {
 	}
 	logger.Infof("Completed comparison of %d methods", len(results))
 
-	return finishComparison(comp, openrpcFailOnDiff)
+	return finishComparison(comp, openrpcFailOnDiff, openrpcFailOnEnv)
 }
 
 func applyMethodFilter(cfg *comparator.ComparisonConfig, methodsToInclude []string) {

--- a/runner/comparator/block_override.go
+++ b/runner/comparator/block_override.go
@@ -1,0 +1,113 @@
+package comparator
+
+import "strings"
+
+// blockArgIndex maps a method to the positional index of its block argument.
+// eth_getLogs is handled separately because its block lives in the filter
+// object rather than at a fixed position.
+var blockArgIndex = map[string]int{
+	"eth_call":                             1,
+	"eth_estimateGas":                      1,
+	"eth_getCode":                          1,
+	"eth_getBalance":                       1,
+	"eth_getTransactionCount":              1,
+	"eth_getStorageAt":                     2,
+	"eth_getBlockByNumber":                 0,
+	"eth_getBlockReceipts":                 0,
+	"eth_getBlockTransactionCountByNumber": 0,
+	"eth_feeHistory":                       1, // newestBlock
+}
+
+// applyBlockOverride rewrites latest/pending block tags to a static block and
+// appends a block argument to calls that omit one, so archive nodes at
+// different heads can be compared deterministically. The input params are not
+// mutated. Methods without a known block argument are returned unchanged.
+func applyBlockOverride(method string, params []interface{}, block string) []interface{} {
+	if block == "" {
+		return params
+	}
+	if method == "eth_getLogs" {
+		return applyBlockOverrideGetLogs(params, block)
+	}
+	idx, ok := blockArgIndex[method]
+	if !ok {
+		return params
+	}
+	return setBlockArg(params, idx, block)
+}
+
+// setBlockArg sets the block argument at idx to block when it is missing or a
+// rewritable tag, padding with nil if the slice is short.
+func setBlockArg(params []interface{}, idx int, block string) []interface{} {
+	out := append([]interface{}{}, params...)
+	for len(out) <= idx {
+		out = append(out, nil)
+	}
+	if out[idx] == nil || isRewritableTag(out[idx]) {
+		out[idx] = block
+	}
+	return out
+}
+
+// applyBlockOverrideGetLogs pins the filter's fromBlock/toBlock to block when
+// they are missing or a rewritable tag.
+func applyBlockOverrideGetLogs(params []interface{}, block string) []interface{} {
+	if len(params) == 0 {
+		return params
+	}
+	filter, ok := params[0].(map[string]interface{})
+	if !ok {
+		return params
+	}
+	newFilter := make(map[string]interface{}, len(filter)+2)
+	for k, v := range filter {
+		newFilter[k] = v
+	}
+	for _, key := range []string{"fromBlock", "toBlock"} {
+		if v, present := newFilter[key]; !present || isRewritableTag(v) {
+			newFilter[key] = block
+		}
+	}
+	out := append([]interface{}{}, params...)
+	out[0] = newFilter
+	return out
+}
+
+// pinnedBlock returns the numeric block a call is pinned to, when it can be
+// determined from the params. Tag-addressed (latest/pending/earliest) and
+// hash-addressed calls return ok=false.
+func pinnedBlock(method string, params []interface{}) (uint64, bool) {
+	if method == "eth_getLogs" {
+		if len(params) > 0 {
+			if f, ok := params[0].(map[string]interface{}); ok {
+				return hexBlock(f["toBlock"])
+			}
+		}
+		return 0, false
+	}
+	idx, ok := blockArgIndex[method]
+	if !ok || idx >= len(params) {
+		return 0, false
+	}
+	return hexBlock(params[idx])
+}
+
+func hexBlock(v interface{}) (uint64, bool) {
+	s, ok := v.(string)
+	if !ok || !strings.HasPrefix(s, "0x") {
+		return 0, false
+	}
+	b, ok := parseHexBig(s)
+	if !ok {
+		return 0, false
+	}
+	return b.Uint64(), true
+}
+
+func isRewritableTag(v interface{}) bool {
+	s, ok := v.(string)
+	if !ok {
+		return false
+	}
+	return s == "latest" || s == "pending"
+}

--- a/runner/comparator/block_override_test.go
+++ b/runner/comparator/block_override_test.go
@@ -1,0 +1,99 @@
+package comparator
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyBlockOverride(t *testing.T) {
+	block := "0x1406f40"
+	tests := []struct {
+		name   string
+		method string
+		params []interface{}
+		want   []interface{}
+	}{
+		{
+			name:   "eth_call appends block when omitted",
+			method: "eth_call",
+			params: []interface{}{map[string]interface{}{"to": "0xabc"}},
+			want:   []interface{}{map[string]interface{}{"to": "0xabc"}, block},
+		},
+		{
+			name:   "eth_call rewrites latest tag",
+			method: "eth_call",
+			params: []interface{}{map[string]interface{}{"to": "0xabc"}, "latest"},
+			want:   []interface{}{map[string]interface{}{"to": "0xabc"}, block},
+		},
+		{
+			name:   "eth_call leaves explicit block untouched",
+			method: "eth_call",
+			params: []interface{}{map[string]interface{}{"to": "0xabc"}, "0x10"},
+			want:   []interface{}{map[string]interface{}{"to": "0xabc"}, "0x10"},
+		},
+		{
+			name:   "eth_getStorageAt appends at index 2",
+			method: "eth_getStorageAt",
+			params: []interface{}{"0xaddr", "0x0"},
+			want:   []interface{}{"0xaddr", "0x0", block},
+		},
+		{
+			name:   "eth_getBlockByNumber rewrites index 0 pending",
+			method: "eth_getBlockByNumber",
+			params: []interface{}{"pending", true},
+			want:   []interface{}{block, true},
+		},
+		{
+			name:   "unknown method untouched",
+			method: "eth_getBlockByHash",
+			params: []interface{}{"0xhash", true},
+			want:   []interface{}{"0xhash", true},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyBlockOverride(tc.method, tc.params, block)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyBlockOverrideGetLogs(t *testing.T) {
+	block := "0x1406f40"
+	params := []interface{}{map[string]interface{}{"fromBlock": "latest", "address": "0xabc"}}
+	got := applyBlockOverride("eth_getLogs", params, block)
+	filter := got[0].(map[string]interface{})
+	if filter["fromBlock"] != block || filter["toBlock"] != block {
+		t.Errorf("expected fromBlock/toBlock pinned to %s, got %v", block, filter)
+	}
+	if filter["address"] != "0xabc" {
+		t.Errorf("address should be preserved, got %v", filter["address"])
+	}
+	// The original params must not be mutated.
+	if params[0].(map[string]interface{})["fromBlock"] != "latest" {
+		t.Error("input params were mutated")
+	}
+}
+
+func TestPinnedBlock(t *testing.T) {
+	tests := []struct {
+		method string
+		params []interface{}
+		want   uint64
+		ok     bool
+	}{
+		{"eth_getBlockByNumber", []interface{}{"0x10", true}, 16, true},
+		{"eth_getBlockByNumber", []interface{}{"latest", true}, 0, false},
+		{"eth_call", []interface{}{map[string]interface{}{}, "0xff"}, 255, true},
+		{"eth_getLogs", []interface{}{map[string]interface{}{"toBlock": "0x20"}}, 32, true},
+		{"eth_getBlockByHash", []interface{}{"0xhash", true}, 0, false},
+	}
+	for _, tc := range tests {
+		got, ok := pinnedBlock(tc.method, tc.params)
+		if ok != tc.ok || (ok && got != tc.want) {
+			t.Errorf("pinnedBlock(%s,%v)=(%d,%v) want (%d,%v)", tc.method, tc.params, got, ok, tc.want, tc.ok)
+		}
+	}
+}

--- a/runner/comparator/comparator.go
+++ b/runner/comparator/comparator.go
@@ -14,6 +14,11 @@ import (
 	"github.com/jsonrpc-bench/runner/types"
 )
 
+// DefaultDiffOnlyMaxResponseBytes is the response-body cap applied when
+// --diff-only is used without an explicit body-trimming flag, so the report
+// stays small by default. Callers can opt out to retain full bodies.
+const DefaultDiffOnlyMaxResponseBytes = 4096
+
 // ComparisonResult represents the result of comparing responses from different clients
 type ComparisonResult struct {
 	Method          string                 `json:"method"`
@@ -36,6 +41,15 @@ func (r ComparisonResult) hasDifferences() bool {
 // post-filter differences, no transport failures, and no schema errors.
 func (r ComparisonResult) isIdentical() bool {
 	return len(r.Differences) == 0 && len(r.TransportErrors) == 0 && len(r.SchemaErrors) == 0
+}
+
+// isEnvDifference reports whether a differing call's difference stems from an
+// environment/capability error (see classifyError) on some client rather than
+// a real result mismatch. A response is either a result or an error, so a
+// classified error on any client means the difference is that error, not a
+// correctness regression.
+func (r ComparisonResult) isEnvDifference() bool {
+	return r.hasDifferences() && len(r.ErrorClass) > 0
 }
 
 // ComparisonConfig represents the configuration for response comparison.
@@ -497,11 +511,14 @@ func truncateResponses(responses map[string]interface{}, maxBytes int) map[strin
 	return out
 }
 
-// Summary tallies the results by outcome category.
+// Summary tallies the results by outcome category. Differ counts real result
+// mismatches; DifferEnv counts mismatches attributable to an environment or
+// capability error (see classifyError).
 type Summary struct {
 	Total          int
 	Identical      int
 	Differ         int
+	DifferEnv      int
 	TransportError int
 	SchemaError    int
 	EnvError       map[string]int
@@ -514,7 +531,11 @@ func (c *Comparator) Summarize() Summary {
 	for _, r := range c.results {
 		switch {
 		case r.hasDifferences():
-			s.Differ++
+			if r.isEnvDifference() {
+				s.DifferEnv++
+			} else {
+				s.Differ++
+			}
 		case len(r.TransportErrors) > 0:
 			s.TransportError++
 		case len(r.SchemaErrors) > 0:
@@ -529,11 +550,34 @@ func (c *Comparator) Summarize() Summary {
 	return s
 }
 
-// HasDifferences reports whether any call has post-filter differences (used by
-// --fail-on-diff).
+// HasDifferences reports whether any call has post-filter differences,
+// including environment/expected ones.
 func (c *Comparator) HasDifferences() bool {
 	for _, r := range c.results {
 		if r.hasDifferences() {
+			return true
+		}
+	}
+	return false
+}
+
+// HasRealDifferences reports whether any call has a real result mismatch (not
+// attributable to an environment/capability error). This is what --fail-on-diff
+// trips on by default.
+func (c *Comparator) HasRealDifferences() bool {
+	for _, r := range c.results {
+		if r.hasDifferences() && !r.isEnvDifference() {
+			return true
+		}
+	}
+	return false
+}
+
+// HasEnvDifferences reports whether any differing call is attributable to an
+// environment/capability error.
+func (c *Comparator) HasEnvDifferences() bool {
+	for _, r := range c.results {
+		if r.isEnvDifference() {
 			return true
 		}
 	}
@@ -591,4 +635,17 @@ func (c *Comparator) GenerateReport(outputPath string) error {
 // GetResults returns all comparison results
 func (c *Comparator) GetResults() []ComparisonResult {
 	return c.results
+}
+
+// MergeComparisonRules layers rules from a --rules file on top of the rules
+// already on the config. Layered rules are evaluated first, so they take
+// precedence over config rules on the same path.
+func (c *ComparisonConfig) MergeComparisonRules(rules []ComparisonRule) {
+	if len(rules) == 0 {
+		return
+	}
+	merged := make([]ComparisonRule, 0, len(rules)+len(c.Rules))
+	merged = append(merged, rules...)
+	merged = append(merged, c.Rules...)
+	c.Rules = merged
 }

--- a/runner/comparator/comparator.go
+++ b/runner/comparator/comparator.go
@@ -16,13 +16,26 @@ import (
 
 // ComparisonResult represents the result of comparing responses from different clients
 type ComparisonResult struct {
-	Method       string                 `json:"method"`
-	Params       []interface{}          `json:"params"`
-	Timestamp    string                 `json:"timestamp"`
-	Responses    map[string]interface{} `json:"responses"`
-	Differences  map[string]interface{} `json:"differences"`
-	SchemaErrors map[string][]string    `json:"schema_errors,omitempty"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty"`
+	Method          string                 `json:"method"`
+	Params          []interface{}          `json:"params"`
+	Timestamp       string                 `json:"timestamp"`
+	Responses       map[string]interface{} `json:"responses"`
+	Differences     map[string]interface{} `json:"differences"`
+	SchemaErrors    map[string][]string    `json:"schema_errors,omitempty"`
+	TransportErrors map[string]string      `json:"transport_errors,omitempty"`
+	ErrorClass      map[string]string      `json:"error_class,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// hasDifferences reports whether the call has any post-filter differences.
+func (r ComparisonResult) hasDifferences() bool {
+	return len(r.Differences) > 0
+}
+
+// isIdentical reports whether every client agreed and nothing went wrong: no
+// post-filter differences, no transport failures, and no schema errors.
+func (r ComparisonResult) isIdentical() bool {
+	return len(r.Differences) == 0 && len(r.TransportErrors) == 0 && len(r.SchemaErrors) == 0
 }
 
 // ComparisonConfig represents the configuration for response comparison.
@@ -43,6 +56,29 @@ type ComparisonConfig struct {
 	Concurrency           int                      `json:"concurrency"`
 	CustomParameters      map[string][]interface{} `json:"custom_parameters,omitempty"`
 	Verbose               bool                     `json:"verbose,omitempty"`
+
+	// Rules declare expected differences (see ComparisonRule). BlockOverride,
+	// when set, rewrites latest/pending block tags to a static block and
+	// appends a block argument to calls that omit one.
+	Rules         []ComparisonRule `json:"rules,omitempty"`
+	BlockOverride string           `json:"block_override,omitempty"`
+
+	// MaxRetries and RetryBaseDelayMs bound transport retries. When unset they
+	// fall back to the per-client ClientConfig.MaxRetries and then to defaults
+	// (5 attempts, 200ms base delay).
+	MaxRetries       int `json:"max_retries,omitempty"`
+	RetryBaseDelayMs int `json:"retry_base_delay_ms,omitempty"`
+
+	// DiffOnly excludes identical calls from serialized output.
+	// OmitMatchingResponses drops full responses (diffs still carry the
+	// differing values). MaxResponseBytes truncates embedded response bodies.
+	DiffOnly              bool `json:"diff_only,omitempty"`
+	OmitMatchingResponses bool `json:"omit_matching_responses,omitempty"`
+	MaxResponseBytes      int  `json:"max_response_bytes,omitempty"`
+
+	// SkipAboveHead skips calls pinned to a numeric block above the lowest
+	// client head.
+	SkipAboveHead bool `json:"skip_above_head,omitempty"`
 }
 
 // Comparator handles comparing responses between different Ethereum clients
@@ -52,7 +88,16 @@ type Comparator struct {
 	outputDir string
 	mutex     sync.Mutex
 	results   []ComparisonResult
+	skipped   []skippedCall
 	verbose   bool
+}
+
+// skippedCall records a call omitted because it pins to a block above the
+// lowest client head (see --skip-above-head).
+type skippedCall struct {
+	Method string `json:"method"`
+	Reason string `json:"reason"`
+	Block  string `json:"block,omitempty"`
 }
 
 // NewComparator creates a new response comparator
@@ -95,6 +140,8 @@ func NewComparator(cfg *ComparisonConfig) (*Comparator, error) {
 func (c *Comparator) CompareResponses(method string, params []interface{}) (*ComparisonResult, error) {
 	responses := make(map[string]interface{})
 	schemaErrors := make(map[string][]string)
+	transportErrors := make(map[string]string)
+	errorClass := make(map[string]string)
 
 	// Recover the real JSON-RPC method name from the identifier; loaders set
 	// MethodRPCNames to point each identifier (e.g. eth_call_variant1) at the
@@ -105,14 +152,28 @@ func (c *Comparator) CompareResponses(method string, params []interface{}) (*Com
 		rpcMethod = name
 	}
 
-	// Make JSON-RPC calls to all clients
+	callParams := params
+	if c.config.BlockOverride != "" {
+		callParams = applyBlockOverride(rpcMethod, params, c.config.BlockOverride)
+	}
+
+	// Make JSON-RPC calls to all clients. A transport failure for one client is
+	// recorded and the run continues, so a single dead endpoint never discards
+	// an otherwise good comparison.
+	answered := make([]*types.ClientConfig, 0, len(c.config.Clients))
 	for _, client := range c.config.Clients {
-		response, err := makeJSONRPCCall(client.URL, rpcMethod, params, c.config.TimeoutSeconds, c.verbose)
+		maxAttempts, baseDelay := c.retryParams(client)
+		response, err := makeJSONRPCCall(client.URL, rpcMethod, callParams, c.config.TimeoutSeconds, c.verbose, maxAttempts, baseDelay)
 		if err != nil {
-			return nil, fmt.Errorf("failed to call %s on %s: %w", rpcMethod, client.Name, err)
+			transportErrors[client.Name] = err.Error()
+			continue
 		}
 
 		responses[client.Name] = response
+		answered = append(answered, client)
+		if cls := classifyError(response); cls != "" {
+			errorClass[client.Name] = cls
+		}
 
 		// Validate response against schema if enabled
 		if c.config.ValidateAgainstSchema && c.validator != nil {
@@ -128,22 +189,21 @@ func (c *Comparator) CompareResponses(method string, params []interface{}) (*Com
 		}
 	}
 
-	// Compare responses between clients
+	// Compare responses between the clients that answered. The reference is the
+	// first answered client (normally config.Clients[0]).
 	differences := make(map[string]interface{})
-	if len(c.config.Clients) >= 2 {
-		// Use first client as reference
-		refClient := c.config.Clients[0].Name
-		refResponse := responses[refClient].(map[string]interface{})
+	if len(answered) >= 2 {
+		refResponse := responses[answered[0].Name].(map[string]interface{})
+		ctx := newDiffContext(rpcMethod, c.config.Rules)
 
-		// Compare with other clients
-		for _, client := range c.config.Clients[1:] {
+		for _, client := range answered[1:] {
 			clientResponse := responses[client.Name].(map[string]interface{})
-			diff, err := compareJSONRPCResponses(refResponse, clientResponse)
+			diff, err := compareJSONRPCResponses(ctx, refResponse, clientResponse)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compare responses: %w", err)
 			}
 
-			if diff != nil && len(diff) > 0 {
+			if len(diff) > 0 {
 				differences[client.Name] = diff
 			}
 		}
@@ -151,12 +211,14 @@ func (c *Comparator) CompareResponses(method string, params []interface{}) (*Com
 
 	// Create comparison result
 	result := &ComparisonResult{
-		Method:       method,
-		Params:       params,
-		Timestamp:    time.Now().Format(time.RFC3339),
-		Responses:    responses,
-		Differences:  differences,
-		SchemaErrors: schemaErrors,
+		Method:          method,
+		Params:          params,
+		Timestamp:       time.Now().Format(time.RFC3339),
+		Responses:       responses,
+		Differences:     differences,
+		SchemaErrors:    schemaErrors,
+		TransportErrors: transportErrors,
+		ErrorClass:      errorClass,
 		Metadata: map[string]interface{}{
 			"clients": c.config.Clients,
 		},
@@ -170,6 +232,24 @@ func (c *Comparator) CompareResponses(method string, params []interface{}) (*Com
 	return result, nil
 }
 
+// retryParams resolves the retry budget: an explicit config value (from the
+// --max-retries / --retry-base-delay flags) wins, then the per-client
+// ClientConfig.MaxRetries, then the defaults (5 attempts, 200ms base delay).
+func (c *Comparator) retryParams(client *types.ClientConfig) (maxAttempts int, baseDelay time.Duration) {
+	maxAttempts = c.config.MaxRetries
+	if maxAttempts <= 0 && client != nil {
+		maxAttempts = client.MaxRetries
+	}
+	if maxAttempts <= 0 {
+		maxAttempts = 5
+	}
+	baseDelay = time.Duration(c.config.RetryBaseDelayMs) * time.Millisecond
+	if baseDelay <= 0 {
+		baseDelay = 200 * time.Millisecond
+	}
+	return maxAttempts, baseDelay
+}
+
 // VerifyNetworkConsistency checks if all clients are on the same network by comparing eth_chainId
 func (c *Comparator) VerifyNetworkConsistency() error {
 	// Skip if there's only one client
@@ -180,7 +260,8 @@ func (c *Comparator) VerifyNetworkConsistency() error {
 	// Get chainId from all clients
 	chainIDs := make(map[string]string)
 	for _, client := range c.config.Clients {
-		response, err := makeJSONRPCCall(client.URL, "eth_chainId", []interface{}{}, c.config.TimeoutSeconds, c.verbose)
+		maxAttempts, baseDelay := c.retryParams(client)
+		response, err := makeJSONRPCCall(client.URL, "eth_chainId", []interface{}{}, c.config.TimeoutSeconds, c.verbose, maxAttempts, baseDelay)
 		if err != nil {
 			return fmt.Errorf("failed to get chainId from %s: %w", client.Name, err)
 		}
@@ -274,6 +355,12 @@ func (c *Comparator) Run() ([]ComparisonResult, error) {
 		return nil, err
 	}
 
+	if c.config.SkipAboveHead {
+		if err := c.applySkipAboveHead(); err != nil {
+			return nil, err
+		}
+	}
+
 	// Run comparisons
 	results, err := c.RunComparisons()
 	if err != nil {
@@ -283,7 +370,69 @@ func (c *Comparator) Run() ([]ComparisonResult, error) {
 	return results, nil
 }
 
-// SaveResults saves comparison results to a JSON file
+// applySkipAboveHead removes methods pinned to a numeric block above the lowest
+// client head, so a less-synced client does not produce false differences.
+// Hash-addressed calls (e.g. eth_getBlockByHash) cannot be checked numerically
+// and are always kept.
+func (c *Comparator) applySkipAboveHead() error {
+	lowestHead, err := c.lowestHead()
+	if err != nil {
+		return err
+	}
+	if c.verbose {
+		log.Printf("skip-above-head: lowest client head is %d", lowestHead)
+	}
+
+	kept := make([]string, 0, len(c.config.Methods))
+	for _, method := range c.config.Methods {
+		rpcMethod := method
+		if name, ok := c.config.MethodRPCNames[method]; ok && name != "" {
+			rpcMethod = name
+		}
+		block, ok := pinnedBlock(rpcMethod, c.config.CustomParameters[method])
+		if ok && block > lowestHead {
+			c.skipped = append(c.skipped, skippedCall{
+				Method: method,
+				Reason: "pinned block above lowest client head",
+				Block:  fmt.Sprintf("0x%x", block),
+			})
+			continue
+		}
+		kept = append(kept, method)
+	}
+	c.config.Methods = kept
+	return nil
+}
+
+// lowestHead returns the minimum eth_blockNumber across all clients.
+func (c *Comparator) lowestHead() (uint64, error) {
+	var lowest uint64
+	first := true
+	for _, client := range c.config.Clients {
+		maxAttempts, baseDelay := c.retryParams(client)
+		resp, err := makeJSONRPCCall(client.URL, "eth_blockNumber", []interface{}{}, c.config.TimeoutSeconds, c.verbose, maxAttempts, baseDelay)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get head from %s: %w", client.Name, err)
+		}
+		s, ok := resp["result"].(string)
+		if !ok {
+			return 0, fmt.Errorf("invalid eth_blockNumber from %s", client.Name)
+		}
+		head, ok := parseHexBig(s)
+		if !ok {
+			return 0, fmt.Errorf("invalid eth_blockNumber %q from %s", s, client.Name)
+		}
+		h := head.Uint64()
+		if first || h < lowest {
+			lowest = h
+			first = false
+		}
+	}
+	return lowest, nil
+}
+
+// SaveResults saves comparison results to a JSON file, honoring the diff-only
+// and response-trimming output options.
 func (c *Comparator) SaveResults(filename string) error {
 	// Use the provided filename directly as it should already be a full path
 	outputPath := filename
@@ -295,7 +444,7 @@ func (c *Comparator) SaveResults(filename string) error {
 	}
 
 	// Marshal results to JSON
-	data, err := json.MarshalIndent(c.results, "", "  ")
+	data, err := json.MarshalIndent(c.resultsForOutput(), "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal results: %w", err)
 	}
@@ -305,6 +454,131 @@ func (c *Comparator) SaveResults(filename string) error {
 		return fmt.Errorf("failed to write results: %w", err)
 	}
 
+	return nil
+}
+
+// resultsForOutput applies the output options (--diff-only,
+// --omit-matching-responses, --max-response-bytes) to a copy of the results so
+// serialization stays small. The stored results are never mutated.
+func (c *Comparator) resultsForOutput() []ComparisonResult {
+	out := make([]ComparisonResult, 0, len(c.results))
+	for _, r := range c.results {
+		if c.config.DiffOnly && r.isIdentical() {
+			continue
+		}
+		if c.config.OmitMatchingResponses {
+			r.Responses = nil
+		} else if c.config.MaxResponseBytes > 0 {
+			r.Responses = truncateResponses(r.Responses, c.config.MaxResponseBytes)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// truncateResponses replaces any response whose JSON encoding exceeds maxBytes
+// with a small placeholder, so large block bodies do not bloat the report.
+func truncateResponses(responses map[string]interface{}, maxBytes int) map[string]interface{} {
+	if responses == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(responses))
+	for name, resp := range responses {
+		encoded, err := json.Marshal(resp)
+		if err == nil && len(encoded) > maxBytes {
+			out[name] = map[string]interface{}{
+				"_truncated": true,
+				"_bytes":     len(encoded),
+			}
+			continue
+		}
+		out[name] = resp
+	}
+	return out
+}
+
+// Summary tallies the results by outcome category.
+type Summary struct {
+	Total          int
+	Identical      int
+	Differ         int
+	TransportError int
+	SchemaError    int
+	EnvError       map[string]int
+	Skipped        int
+}
+
+// Summarize computes the outcome tally for the completed run.
+func (c *Comparator) Summarize() Summary {
+	s := Summary{Total: len(c.results), EnvError: map[string]int{}, Skipped: len(c.skipped)}
+	for _, r := range c.results {
+		switch {
+		case r.hasDifferences():
+			s.Differ++
+		case len(r.TransportErrors) > 0:
+			s.TransportError++
+		case len(r.SchemaErrors) > 0:
+			s.SchemaError++
+		default:
+			s.Identical++
+		}
+		for _, cls := range r.ErrorClass {
+			s.EnvError[cls]++
+		}
+	}
+	return s
+}
+
+// HasDifferences reports whether any call has post-filter differences (used by
+// --fail-on-diff).
+func (c *Comparator) HasDifferences() bool {
+	for _, r := range c.results {
+		if r.hasDifferences() {
+			return true
+		}
+	}
+	return false
+}
+
+// Provenance returns the effective comparison configuration so a report is
+// self-describing and reproducible.
+func (c *Comparator) Provenance() map[string]interface{} {
+	clientRefs := make([]string, 0, len(c.config.Clients))
+	for _, client := range c.config.Clients {
+		clientRefs = append(clientRefs, client.Name)
+	}
+	return map[string]interface{}{
+		"name":                    c.config.Name,
+		"description":             c.config.Description,
+		"generated_at":            time.Now().Format(time.RFC3339),
+		"client_refs":             clientRefs,
+		"block_override":          c.config.BlockOverride,
+		"rules":                   c.config.Rules,
+		"concurrency":             c.config.Concurrency,
+		"timeout_seconds":         c.config.TimeoutSeconds,
+		"validate_against_schema": c.config.ValidateAgainstSchema,
+		"diff_only":               c.config.DiffOnly,
+		"omit_matching_responses": c.config.OmitMatchingResponses,
+		"max_response_bytes":      c.config.MaxResponseBytes,
+		"skip_above_head":         c.config.SkipAboveHead,
+		"call_count":              len(c.config.Methods),
+		"skipped":                 c.skipped,
+	}
+}
+
+// SaveProvenance writes the effective configuration to a sidecar JSON file.
+func (c *Comparator) SaveProvenance(filename string) error {
+	dir := filepath.Dir(filename)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+	data, err := json.MarshalIndent(c.Provenance(), "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal provenance: %w", err)
+	}
+	if err := os.WriteFile(filename, data, 0644); err != nil {
+		return fmt.Errorf("failed to write provenance: %w", err)
+	}
 	return nil
 }
 
@@ -318,4 +592,3 @@ func (c *Comparator) GenerateReport(outputPath string) error {
 func (c *Comparator) GetResults() []ComparisonResult {
 	return c.results
 }
-

--- a/runner/comparator/compare_config.go
+++ b/runner/comparator/compare_config.go
@@ -33,6 +33,64 @@ type comparisonBlock struct {
 	Rules         []ComparisonRule `yaml:"rules"`
 }
 
+// rulesFile is the on-disk shape of a standalone --rules file. The rules may
+// be nested under a `comparison:` key (matching a compare config) or given at
+// the document root for convenience.
+type rulesFile struct {
+	Comparison    *comparisonBlock `yaml:"comparison"`
+	BlockOverride string           `yaml:"block_override"`
+	Rules         []ComparisonRule `yaml:"rules"`
+}
+
+// validateRuleKinds returns an error describing the first rule with an unknown
+// kind, using ctx to identify where the rule came from.
+func validateRuleKinds(rules []ComparisonRule, ctx string) error {
+	for i, rule := range rules {
+		if !ValidRuleKind(rule.Kind) {
+			return fmt.Errorf("%s: rules[%d]: unknown kind %q (want ignore, numeric_tolerance, error_code_only or error_presence_only)", ctx, i, rule.Kind)
+		}
+	}
+	return nil
+}
+
+// LoadComparisonRules loads a --rules file holding a `comparison:` block (or a
+// bare rules/block_override at the root) and returns the parsed rules and block
+// override for merging into a config in either --config or --from-jsonl mode.
+func LoadComparisonRules(path string) ([]ComparisonRule, string, error) {
+	safePath, err := config.SafeReadPath(path)
+	if err != nil {
+		return nil, "", err
+	}
+	data, err := os.ReadFile(safePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read rules file: %w", err)
+	}
+
+	var file rulesFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, "", fmt.Errorf("failed to parse rules file: %w", err)
+	}
+
+	rules := file.Rules
+	blockOverride := file.BlockOverride
+	if file.Comparison != nil {
+		if len(file.Comparison.Rules) > 0 {
+			rules = file.Comparison.Rules
+		}
+		if file.Comparison.BlockOverride != "" {
+			blockOverride = file.Comparison.BlockOverride
+		}
+	}
+
+	if len(rules) == 0 && blockOverride == "" {
+		return nil, "", fmt.Errorf("rules file %q defines no rules or block_override", path)
+	}
+	if err := validateRuleKinds(rules, "rules file"); err != nil {
+		return nil, "", err
+	}
+	return rules, blockOverride, nil
+}
+
 // methodCalls preserves the order of methods as they appear in the YAML.
 type methodCalls struct {
 	Method string
@@ -86,10 +144,8 @@ func LoadCompareConfig(path string) (*ComparisonConfig, error) {
 
 	if file.Comparison != nil {
 		cfg.BlockOverride = file.Comparison.BlockOverride
-		for i, rule := range file.Comparison.Rules {
-			if !ValidRuleKind(rule.Kind) {
-				return nil, fmt.Errorf("compare config: comparison.rules[%d]: unknown kind %q (want ignore, numeric_tolerance, error_code_only or error_presence_only)", i, rule.Kind)
-			}
+		if err := validateRuleKinds(file.Comparison.Rules, "compare config: comparison"); err != nil {
+			return nil, err
 		}
 		cfg.Rules = file.Comparison.Rules
 	}

--- a/runner/comparator/compare_config.go
+++ b/runner/comparator/compare_config.go
@@ -18,11 +18,19 @@ type compareCall struct {
 
 // compareFile is the on-disk shape of a compare YAML config.
 type compareFile struct {
-	Name        string                   `yaml:"name"`
-	Description string                   `yaml:"description"`
-	Calls       yaml.Node                `yaml:"calls"`
+	Name        string           `yaml:"name"`
+	Description string           `yaml:"description"`
+	Calls       yaml.Node        `yaml:"calls"`
+	Comparison  *comparisonBlock `yaml:"comparison"`
 	// Populated from Calls after decoding; preserves insertion order.
 	calls []methodCalls `yaml:"-"`
+}
+
+// comparisonBlock is the optional `comparison:` section declaring expected
+// differences and the block override.
+type comparisonBlock struct {
+	BlockOverride string           `yaml:"block_override"`
+	Rules         []ComparisonRule `yaml:"rules"`
 }
 
 // methodCalls preserves the order of methods as they appear in the YAML.
@@ -74,6 +82,16 @@ func LoadCompareConfig(path string) (*ComparisonConfig, error) {
 		Methods:          make([]string, 0),
 		MethodRPCNames:   make(map[string]string),
 		CustomParameters: make(map[string][]interface{}),
+	}
+
+	if file.Comparison != nil {
+		cfg.BlockOverride = file.Comparison.BlockOverride
+		for i, rule := range file.Comparison.Rules {
+			if !ValidRuleKind(rule.Kind) {
+				return nil, fmt.Errorf("compare config: comparison.rules[%d]: unknown kind %q (want ignore, numeric_tolerance, error_code_only or error_presence_only)", i, rule.Kind)
+			}
+		}
+		cfg.Rules = file.Comparison.Rules
 	}
 
 	for _, m := range file.calls {

--- a/runner/comparator/compare_config_test.go
+++ b/runner/comparator/compare_config_test.go
@@ -161,6 +161,59 @@ calls:
 	}
 }
 
+func TestLoadCompareConfig_ComparisonBlock(t *testing.T) {
+	path := writeCompareFixture(t, `
+name: "with rules"
+comparison:
+  block_override: "0x1406f40"
+  rules:
+    - method: eth_estimateGas
+      path: result
+      kind: numeric_tolerance
+      rel: 0.1
+    - path: result.totalDifficulty
+      kind: ignore
+    - method: eth_getStorageAt
+      kind: error_code_only
+calls:
+  eth_blockNumber:
+    - params: []
+`)
+	cfg, err := LoadCompareConfig(path)
+	if err != nil {
+		t.Fatalf("LoadCompareConfig: %v", err)
+	}
+	if cfg.BlockOverride != "0x1406f40" {
+		t.Errorf("BlockOverride = %q, want 0x1406f40", cfg.BlockOverride)
+	}
+	if len(cfg.Rules) != 3 {
+		t.Fatalf("Rules len = %d, want 3", len(cfg.Rules))
+	}
+	if cfg.Rules[0].Kind != RuleNumericTolerance || cfg.Rules[0].Rel != 0.1 || cfg.Rules[0].Method != "eth_estimateGas" {
+		t.Errorf("rule[0] round-trip failed: %+v", cfg.Rules[0])
+	}
+	if cfg.Rules[1].Kind != RuleIgnore || cfg.Rules[1].Path != "result.totalDifficulty" {
+		t.Errorf("rule[1] round-trip failed: %+v", cfg.Rules[1])
+	}
+}
+
+func TestLoadCompareConfig_UnknownRuleKind(t *testing.T) {
+	path := writeCompareFixture(t, `
+name: "bad rule"
+comparison:
+  rules:
+    - path: result
+      kind: bogus
+calls:
+  eth_blockNumber:
+    - params: []
+`)
+	_, err := LoadCompareConfig(path)
+	if err == nil || !strings.Contains(err.Error(), "unknown kind") {
+		t.Fatalf("expected unknown kind error, got %v", err)
+	}
+}
+
 func TestLoadCompareConfig_Errors(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/runner/comparator/corpus.go
+++ b/runner/comparator/corpus.go
@@ -2,8 +2,10 @@ package comparator
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -16,14 +18,21 @@ import (
 // corpusExcluded lists methods that are unsuitable for cross-client archive
 // correctness comparison: proofs are not always stored, and head-dependent
 // methods diverge legitimately between nodes at different heads. The debug_
-// namespace is excluded by prefix.
+// namespace is excluded by prefix. eth_feeHistory is excluded only when no
+// block override is set — with a static newestBlock it is deterministic (see
+// isCorpusExcluded).
 var corpusExcluded = map[string]struct{}{
 	"eth_getProof":             {},
 	"eth_gasPrice":             {},
 	"eth_syncing":              {},
 	"eth_blockNumber":          {},
 	"eth_maxPriorityFeePerGas": {},
-	"eth_feeHistory":           {},
+}
+
+// corpusPinnable lists methods excluded by default but kept when a block
+// override pins them to a static block.
+var corpusPinnable = map[string]struct{}{
+	"eth_feeHistory": {},
 }
 
 type corpusEntry struct {
@@ -31,44 +40,45 @@ type corpusEntry struct {
 	Params []interface{} `json:"params"`
 }
 
-// LoadCorpusConfig builds a ComparisonConfig by ingesting rpc-calls/*.jsonl
-// files under dir. Each line is a {method, params} object. When sample > 0 at
-// most that many calls per method are kept, chosen deterministically from seed.
-// Excluded methods (see corpusExcluded and the debug_ prefix) are dropped.
-func LoadCorpusConfig(dir string, sample int, seed int64) (*ComparisonConfig, error) {
-	matches, err := filepath.Glob(filepath.Join(dir, "*.jsonl"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to scan corpus dir: %w", err)
+// LoadCorpusConfig builds a ComparisonConfig by ingesting a corpus directory
+// recursively. It reads both line-delimited *.jsonl files and *.json files
+// holding a JSON array of {method, params} objects. When sample > 0 at most
+// that many calls per method are kept, chosen deterministically from seed.
+// Excluded methods (see corpusExcluded and the debug_ prefix) are dropped;
+// pinnable methods like eth_feeHistory are kept when blockOverride is set.
+func LoadCorpusConfig(dir string, sample int, seed int64, blockOverride string) (*ComparisonConfig, error) {
+	var files []string
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".jsonl") || strings.HasSuffix(path, ".json") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("failed to scan corpus dir: %w", walkErr)
 	}
-	if len(matches) == 0 {
-		return nil, fmt.Errorf("no .jsonl files found in %s", dir)
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no .jsonl or .json files found under %s", dir)
 	}
-	sort.Strings(matches)
+	sort.Strings(files)
+
+	keepPinnable := blockOverride != ""
 
 	byMethod := make(map[string][][]interface{})
 	order := make([]string, 0)
-	for _, file := range matches {
-		safePath, err := config.SafeReadPath(file)
+	for _, file := range files {
+		entries, err := readCorpusFile(file)
 		if err != nil {
 			return nil, err
 		}
-		f, err := os.Open(safePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open corpus file %s: %w", file, err)
-		}
-		scanner := bufio.NewScanner(f)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			if line == "" {
-				continue
-			}
-			var entry corpusEntry
-			if err := json.Unmarshal([]byte(line), &entry); err != nil {
-				f.Close()
-				return nil, fmt.Errorf("failed to parse %s: %w", file, err)
-			}
-			if entry.Method == "" || isCorpusExcluded(entry.Method) {
+		for _, entry := range entries {
+			if entry.Method == "" || isCorpusExcluded(entry.Method, keepPinnable) {
 				continue
 			}
 			if entry.Params == nil {
@@ -79,11 +89,6 @@ func LoadCorpusConfig(dir string, sample int, seed int64) (*ComparisonConfig, er
 			}
 			byMethod[entry.Method] = append(byMethod[entry.Method], entry.Params)
 		}
-		if err := scanner.Err(); err != nil {
-			f.Close()
-			return nil, fmt.Errorf("failed to read %s: %w", file, err)
-		}
-		f.Close()
 	}
 
 	if len(order) == 0 {
@@ -113,6 +118,46 @@ func LoadCorpusConfig(dir string, sample int, seed int64) (*ComparisonConfig, er
 	return cfg, nil
 }
 
+// readCorpusFile parses one corpus file. A .json file is a JSON array of
+// entries; a .jsonl file is one entry per line.
+func readCorpusFile(path string) ([]corpusEntry, error) {
+	safePath, err := config.SafeReadPath(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(safePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read corpus file %s: %w", path, err)
+	}
+
+	if strings.HasSuffix(path, ".json") {
+		var entries []corpusEntry
+		if err := json.Unmarshal(data, &entries); err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+		}
+		return entries, nil
+	}
+
+	var entries []corpusEntry
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry corpusEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	return entries, nil
+}
+
 // sampleCalls returns at most n calls, chosen with a seeded shuffle so the
 // selection is reproducible, preserving original order within the selection.
 func sampleCalls(calls [][]interface{}, n int, rng *rand.Rand) [][]interface{} {
@@ -133,10 +178,15 @@ func sampleCalls(calls [][]interface{}, n int, rng *rand.Rand) [][]interface{} {
 	return out
 }
 
-func isCorpusExcluded(method string) bool {
+func isCorpusExcluded(method string, keepPinnable bool) bool {
 	if strings.HasPrefix(method, "debug_") {
 		return true
 	}
-	_, ok := corpusExcluded[method]
-	return ok
+	if _, ok := corpusExcluded[method]; ok {
+		return true
+	}
+	if _, ok := corpusPinnable[method]; ok {
+		return !keepPinnable
+	}
+	return false
 }

--- a/runner/comparator/corpus.go
+++ b/runner/comparator/corpus.go
@@ -1,0 +1,142 @@
+package comparator
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jsonrpc-bench/runner/config"
+)
+
+// corpusExcluded lists methods that are unsuitable for cross-client archive
+// correctness comparison: proofs are not always stored, and head-dependent
+// methods diverge legitimately between nodes at different heads. The debug_
+// namespace is excluded by prefix.
+var corpusExcluded = map[string]struct{}{
+	"eth_getProof":             {},
+	"eth_gasPrice":             {},
+	"eth_syncing":              {},
+	"eth_blockNumber":          {},
+	"eth_maxPriorityFeePerGas": {},
+	"eth_feeHistory":           {},
+}
+
+type corpusEntry struct {
+	Method string        `json:"method"`
+	Params []interface{} `json:"params"`
+}
+
+// LoadCorpusConfig builds a ComparisonConfig by ingesting rpc-calls/*.jsonl
+// files under dir. Each line is a {method, params} object. When sample > 0 at
+// most that many calls per method are kept, chosen deterministically from seed.
+// Excluded methods (see corpusExcluded and the debug_ prefix) are dropped.
+func LoadCorpusConfig(dir string, sample int, seed int64) (*ComparisonConfig, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.jsonl"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan corpus dir: %w", err)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no .jsonl files found in %s", dir)
+	}
+	sort.Strings(matches)
+
+	byMethod := make(map[string][][]interface{})
+	order := make([]string, 0)
+	for _, file := range matches {
+		safePath, err := config.SafeReadPath(file)
+		if err != nil {
+			return nil, err
+		}
+		f, err := os.Open(safePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open corpus file %s: %w", file, err)
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			var entry corpusEntry
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				f.Close()
+				return nil, fmt.Errorf("failed to parse %s: %w", file, err)
+			}
+			if entry.Method == "" || isCorpusExcluded(entry.Method) {
+				continue
+			}
+			if entry.Params == nil {
+				entry.Params = []interface{}{}
+			}
+			if _, seen := byMethod[entry.Method]; !seen {
+				order = append(order, entry.Method)
+			}
+			byMethod[entry.Method] = append(byMethod[entry.Method], entry.Params)
+		}
+		if err := scanner.Err(); err != nil {
+			f.Close()
+			return nil, fmt.Errorf("failed to read %s: %w", file, err)
+		}
+		f.Close()
+	}
+
+	if len(order) == 0 {
+		return nil, fmt.Errorf("corpus in %s contained no usable calls after exclusions", dir)
+	}
+	sort.Strings(order)
+
+	rng := rand.New(rand.NewSource(seed))
+	cfg := &ComparisonConfig{
+		Name:             fmt.Sprintf("corpus:%s", filepath.Base(strings.TrimRight(dir, "/"))),
+		Description:      fmt.Sprintf("Sampled from %s (sample=%d)", dir, sample),
+		Methods:          make([]string, 0),
+		MethodRPCNames:   make(map[string]string),
+		CustomParameters: make(map[string][]interface{}),
+	}
+
+	for _, method := range order {
+		calls := sampleCalls(byMethod[method], sample, rng)
+		for i, params := range calls {
+			identifier := fmt.Sprintf("%s_variant%d", method, i+1)
+			cfg.Methods = append(cfg.Methods, identifier)
+			cfg.MethodRPCNames[identifier] = method
+			cfg.CustomParameters[identifier] = params
+		}
+	}
+
+	return cfg, nil
+}
+
+// sampleCalls returns at most n calls, chosen with a seeded shuffle so the
+// selection is reproducible, preserving original order within the selection.
+func sampleCalls(calls [][]interface{}, n int, rng *rand.Rand) [][]interface{} {
+	if n <= 0 || len(calls) <= n {
+		return calls
+	}
+	idx := make([]int, len(calls))
+	for i := range idx {
+		idx[i] = i
+	}
+	rng.Shuffle(len(idx), func(i, j int) { idx[i], idx[j] = idx[j], idx[i] })
+	chosen := idx[:n]
+	sort.Ints(chosen)
+	out := make([][]interface{}, 0, n)
+	for _, i := range chosen {
+		out = append(out, calls[i])
+	}
+	return out
+}
+
+func isCorpusExcluded(method string) bool {
+	if strings.HasPrefix(method, "debug_") {
+		return true
+	}
+	_, ok := corpusExcluded[method]
+	return ok
+}

--- a/runner/comparator/corpus_test.go
+++ b/runner/comparator/corpus_test.go
@@ -1,0 +1,93 @@
+package comparator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCorpus chdirs into a temp dir, writes the given files under a "corpus"
+// subdir, and returns the relative dir (SafeReadPath rejects absolute paths).
+func writeCorpus(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	corpusDir := "corpus"
+	if err := os.Mkdir(corpusDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(corpusDir, name), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return corpusDir
+}
+
+func TestLoadCorpusConfig(t *testing.T) {
+	dir := writeCorpus(t, map[string]string{
+		"eth_call-mainnet.jsonl": `{"method":"eth_call","params":[{"to":"0x1"},"0x10"]}
+{"method":"eth_call","params":[{"to":"0x2"},"0x11"]}
+{"method":"eth_call","params":[{"to":"0x3"},"0x12"]}
+`,
+		"excluded.jsonl": `{"method":"eth_getProof","params":[]}
+{"method":"eth_blockNumber","params":[]}
+{"method":"debug_traceCall","params":[]}
+`,
+	})
+
+	cfg, err := LoadCorpusConfig(dir, 0, 42)
+	if err != nil {
+		t.Fatalf("LoadCorpusConfig: %v", err)
+	}
+	if len(cfg.Methods) != 3 {
+		t.Fatalf("expected 3 eth_call variants, got %d (%v)", len(cfg.Methods), cfg.Methods)
+	}
+	for _, id := range cfg.Methods {
+		if cfg.MethodRPCNames[id] != "eth_call" {
+			t.Errorf("identifier %q maps to %q, want eth_call", id, cfg.MethodRPCNames[id])
+		}
+	}
+}
+
+func TestLoadCorpusConfigSampling(t *testing.T) {
+	lines := ""
+	for i := 0; i < 10; i++ {
+		lines += `{"method":"eth_getBalance","params":["0xabc","0x` + string(rune('0'+i)) + `"]}` + "\n"
+	}
+	dir := writeCorpus(t, map[string]string{"eth_getBalance.jsonl": lines})
+
+	cfg, err := LoadCorpusConfig(dir, 3, 42)
+	if err != nil {
+		t.Fatalf("LoadCorpusConfig: %v", err)
+	}
+	if len(cfg.Methods) != 3 {
+		t.Fatalf("expected sample cap of 3, got %d", len(cfg.Methods))
+	}
+
+	// Sampling is deterministic for a fixed seed.
+	cfg2, _ := LoadCorpusConfig(dir, 3, 42)
+	for i, id := range cfg.Methods {
+		a := fmt.Sprintf("%v", cfg.CustomParameters[id])
+		b := fmt.Sprintf("%v", cfg2.CustomParameters[cfg2.Methods[i]])
+		if a != b {
+			t.Errorf("sampling not deterministic at %d: %s vs %s", i, a, b)
+		}
+	}
+}
+
+func TestLoadCorpusConfigAllExcluded(t *testing.T) {
+	dir := writeCorpus(t, map[string]string{"only.jsonl": `{"method":"eth_getProof","params":[]}` + "\n"})
+	if _, err := LoadCorpusConfig(dir, 0, 42); err == nil {
+		t.Error("expected error when corpus is empty after exclusions")
+	}
+}

--- a/runner/comparator/corpus_test.go
+++ b/runner/comparator/corpus_test.go
@@ -45,7 +45,7 @@ func TestLoadCorpusConfig(t *testing.T) {
 `,
 	})
 
-	cfg, err := LoadCorpusConfig(dir, 0, 42)
+	cfg, err := LoadCorpusConfig(dir, 0, 42, "")
 	if err != nil {
 		t.Fatalf("LoadCorpusConfig: %v", err)
 	}
@@ -59,6 +59,59 @@ func TestLoadCorpusConfig(t *testing.T) {
 	}
 }
 
+func TestLoadCorpusConfigRecursesAndReadsJSON(t *testing.T) {
+	dir := writeCorpus(t, map[string]string{
+		"top.jsonl":  `{"method":"eth_getCode","params":["0xabc","0x10"]}` + "\n",
+		"array.json": `[{"method":"eth_call","params":[{"to":"0x1"},"0x10"]},{"method":"eth_call","params":[{"to":"0x2"},"0x11"]}]`,
+	})
+	// A nested subdirectory should be walked too.
+	if err := os.MkdirAll(filepath.Join(dir, "contracts"), 0o755); err != nil {
+		t.Fatalf("mkdir contracts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "contracts", "weth.jsonl"), []byte(`{"method":"eth_getStorageAt","params":["0xabc","0x0","0x10"]}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write nested: %v", err)
+	}
+
+	cfg, err := LoadCorpusConfig(dir, 0, 42, "")
+	if err != nil {
+		t.Fatalf("LoadCorpusConfig: %v", err)
+	}
+	methods := map[string]int{}
+	for _, id := range cfg.Methods {
+		methods[cfg.MethodRPCNames[id]]++
+	}
+	if methods["eth_getCode"] != 1 {
+		t.Errorf("expected 1 eth_getCode from top-level .jsonl, got %d", methods["eth_getCode"])
+	}
+	if methods["eth_call"] != 2 {
+		t.Errorf("expected 2 eth_call from .json array, got %d", methods["eth_call"])
+	}
+	if methods["eth_getStorageAt"] != 1 {
+		t.Errorf("expected 1 eth_getStorageAt from nested subdir, got %d", methods["eth_getStorageAt"])
+	}
+}
+
+func TestLoadCorpusConfigFeeHistoryPinning(t *testing.T) {
+	dir := writeCorpus(t, map[string]string{
+		"fee.jsonl": `{"method":"eth_feeHistory","params":["0x5","latest",[]]}` + "\n",
+	})
+
+	// Without a block override, eth_feeHistory is head-dependent and excluded,
+	// leaving an empty corpus.
+	if _, err := LoadCorpusConfig(dir, 0, 42, ""); err == nil {
+		t.Error("expected eth_feeHistory to be excluded without a block override")
+	}
+
+	// With a block override it is pinnable and kept.
+	cfg, err := LoadCorpusConfig(dir, 0, 42, "0x1406f40")
+	if err != nil {
+		t.Fatalf("LoadCorpusConfig with block override: %v", err)
+	}
+	if len(cfg.Methods) != 1 || cfg.MethodRPCNames[cfg.Methods[0]] != "eth_feeHistory" {
+		t.Errorf("expected eth_feeHistory kept when pinned, got %v", cfg.Methods)
+	}
+}
+
 func TestLoadCorpusConfigSampling(t *testing.T) {
 	lines := ""
 	for i := 0; i < 10; i++ {
@@ -66,7 +119,7 @@ func TestLoadCorpusConfigSampling(t *testing.T) {
 	}
 	dir := writeCorpus(t, map[string]string{"eth_getBalance.jsonl": lines})
 
-	cfg, err := LoadCorpusConfig(dir, 3, 42)
+	cfg, err := LoadCorpusConfig(dir, 3, 42, "")
 	if err != nil {
 		t.Fatalf("LoadCorpusConfig: %v", err)
 	}
@@ -75,7 +128,7 @@ func TestLoadCorpusConfigSampling(t *testing.T) {
 	}
 
 	// Sampling is deterministic for a fixed seed.
-	cfg2, _ := LoadCorpusConfig(dir, 3, 42)
+	cfg2, _ := LoadCorpusConfig(dir, 3, 42, "")
 	for i, id := range cfg.Methods {
 		a := fmt.Sprintf("%v", cfg.CustomParameters[id])
 		b := fmt.Sprintf("%v", cfg2.CustomParameters[cfg2.Methods[i]])
@@ -87,7 +140,7 @@ func TestLoadCorpusConfigSampling(t *testing.T) {
 
 func TestLoadCorpusConfigAllExcluded(t *testing.T) {
 	dir := writeCorpus(t, map[string]string{"only.jsonl": `{"method":"eth_getProof","params":[]}` + "\n"})
-	if _, err := LoadCorpusConfig(dir, 0, 42); err == nil {
+	if _, err := LoadCorpusConfig(dir, 0, 42, ""); err == nil {
 		t.Error("expected error when corpus is empty after exclusions")
 	}
 }

--- a/runner/comparator/diff.go
+++ b/runner/comparator/diff.go
@@ -37,8 +37,13 @@ type DiffEntry struct {
 	Reference string      `json:"reference,omitempty"`
 }
 
-// compareJSONRPCResponses compares two JSON-RPC responses and returns their differences
-func compareJSONRPCResponses(resp1, resp2 map[string]interface{}) (map[string]interface{}, error) {
+// compareJSONRPCResponses compares two JSON-RPC responses and returns their
+// differences, applying the rules carried by ctx. Passing a nil ctx compares
+// with no rules (the pre-rules behavior).
+func compareJSONRPCResponses(ctx *diffContext, resp1, resp2 map[string]interface{}) (map[string]interface{}, error) {
+	if ctx == nil {
+		ctx = newDiffContext("", nil)
+	}
 	differences := make(map[string]interface{})
 
 	// Check if both have result or error fields
@@ -67,7 +72,7 @@ func compareJSONRPCResponses(resp1, resp2 map[string]interface{}) (map[string]in
 
 	// If both have results, compare them
 	if hasResult1 && hasResult2 {
-		resultDiffs, err := deepCompare("result", result1, result2)
+		resultDiffs, err := deepCompare(ctx, "result", result1, result2)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compare results: %w", err)
 		}
@@ -77,15 +82,30 @@ func compareJSONRPCResponses(resp1, resp2 map[string]interface{}) (map[string]in
 		}
 	}
 
-	// If both have errors, compare them
+	// If both have errors, compare them subject to the error rules.
 	if hasError1 && hasError2 {
-		errorDiffs, err := deepCompare("error", error1, error2)
-		if err != nil {
-			return nil, fmt.Errorf("failed to compare errors: %w", err)
-		}
-
-		if len(errorDiffs) > 0 {
-			differences["error_differences"] = errorDiffs
+		switch {
+		case ctx.rules.errorPresenceOnly:
+			// Both responses errored; treat as equal regardless of code/message.
+		case ctx.rules.errorCodeOnly:
+			code1, _ := errorCode(error1)
+			code2, _ := errorCode(error2)
+			if code1 != code2 {
+				differences["error_differences"] = []DiffEntry{{
+					Path:   "error.code",
+					Type:   DiffTypeValueMismatch,
+					Value1: code1,
+					Value2: code2,
+				}}
+			}
+		default:
+			errorDiffs, err := deepCompare(ctx, "error", error1, error2)
+			if err != nil {
+				return nil, fmt.Errorf("failed to compare errors: %w", err)
+			}
+			if len(errorDiffs) > 0 {
+				differences["error_differences"] = errorDiffs
+			}
 		}
 	}
 
@@ -93,7 +113,12 @@ func compareJSONRPCResponses(resp1, resp2 map[string]interface{}) (map[string]in
 }
 
 // deepCompare recursively compares two values and returns their differences
-func deepCompare(path string, val1, val2 interface{}) ([]DiffEntry, error) {
+func deepCompare(ctx *diffContext, path string, val1, val2 interface{}) ([]DiffEntry, error) {
+	// An ignore rule drops this path (and its whole subtree) from comparison.
+	if ctx.rules.matchesIgnore(path) {
+		return nil, nil
+	}
+
 	// Handle nil values
 	if val1 == nil && val2 == nil {
 		return nil, nil
@@ -125,10 +150,10 @@ func deepCompare(path string, val1, val2 interface{}) ([]DiffEntry, error) {
 	// Compare based on type
 	switch val1.(type) {
 	case map[string]interface{}:
-		return compareObjects(path, val1.(map[string]interface{}), val2.(map[string]interface{}))
+		return compareObjects(ctx, path, val1.(map[string]interface{}), val2.(map[string]interface{}))
 
 	case []interface{}:
-		return compareArrays(path, val1.([]interface{}), val2.([]interface{}))
+		return compareArrays(ctx, path, val1.([]interface{}), val2.([]interface{}))
 
 	case string, float64, bool, int, int64:
 		// Special case for Ethereum hex strings: treat 0x and 0x0000...0000 as equal
@@ -140,6 +165,12 @@ func deepCompare(path string, val1, val2 interface{}) ([]DiffEntry, error) {
 					if (str1 == "0x" && isZeroHex(str2)) || (str2 == "0x" && isZeroHex(str1)) {
 						// Consider them equal
 						return nil, nil
+					}
+					// A numeric_tolerance rule treats close-enough quantities as equal.
+					if rule, ok := ctx.rules.toleranceFor(path); ok {
+						if applicable, equal := withinTolerance(str1, str2, rule); applicable && equal {
+							return nil, nil
+						}
 					}
 				}
 			}
@@ -180,7 +211,7 @@ func deepCompare(path string, val1, val2 interface{}) ([]DiffEntry, error) {
 }
 
 // compareObjects compares two objects and returns their differences
-func compareObjects(path string, obj1, obj2 map[string]interface{}) ([]DiffEntry, error) {
+func compareObjects(ctx *diffContext, path string, obj1, obj2 map[string]interface{}) ([]DiffEntry, error) {
 	var differences []DiffEntry
 
 	// Get all keys from both objects
@@ -208,6 +239,11 @@ func compareObjects(path string, obj1, obj2 map[string]interface{}) ([]DiffEntry
 			keyPath = key
 		}
 
+		// An ignore rule drops this key entirely, including missing/extra cases.
+		if ctx.rules.matchesIgnore(keyPath) {
+			continue
+		}
+
 		val1, exists1 := obj1[key]
 		val2, exists2 := obj2[key]
 
@@ -233,7 +269,7 @@ func compareObjects(path string, obj1, obj2 map[string]interface{}) ([]DiffEntry
 		}
 
 		// Recursively compare values
-		diffs, err := deepCompare(keyPath, val1, val2)
+		diffs, err := deepCompare(ctx, keyPath, val1, val2)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compare %s: %w", keyPath, err)
 		}
@@ -245,7 +281,7 @@ func compareObjects(path string, obj1, obj2 map[string]interface{}) ([]DiffEntry
 }
 
 // compareArrays compares two arrays and returns their differences
-func compareArrays(path string, arr1, arr2 []interface{}) ([]DiffEntry, error) {
+func compareArrays(ctx *diffContext, path string, arr1, arr2 []interface{}) ([]DiffEntry, error) {
 	var differences []DiffEntry
 
 	// Compare array lengths
@@ -267,7 +303,7 @@ func compareArrays(path string, arr1, arr2 []interface{}) ([]DiffEntry, error) {
 		// Compare elements up to the minimum length
 		for i := 0; i < minLen; i++ {
 			itemPath := fmt.Sprintf("%s[%d]", path, i)
-			diffs, err := deepCompare(itemPath, arr1[i], arr2[i])
+			diffs, err := deepCompare(ctx, itemPath, arr1[i], arr2[i])
 			if err != nil {
 				return nil, fmt.Errorf("failed to compare %s: %w", itemPath, err)
 			}
@@ -281,7 +317,7 @@ func compareArrays(path string, arr1, arr2 []interface{}) ([]DiffEntry, error) {
 	// If lengths are the same, compare all elements
 	for i := 0; i < len(arr1); i++ {
 		itemPath := fmt.Sprintf("%s[%d]", path, i)
-		diffs, err := deepCompare(itemPath, arr1[i], arr2[i])
+		diffs, err := deepCompare(ctx, itemPath, arr1[i], arr2[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to compare %s: %w", itemPath, err)
 		}

--- a/runner/comparator/diff_test.go
+++ b/runner/comparator/diff_test.go
@@ -30,8 +30,10 @@ func TestIsZeroHex(t *testing.T) {
 }
 
 func TestDeepCompareZeroHex(t *testing.T) {
+	ctx := newDiffContext("", nil)
+
 	// Test that 0x and 0x0000...0000 are considered equal
-	diffs, err := deepCompare("result", "0x", "0x0000000000000000000000000000000000000000000000000000000000000000")
+	diffs, err := deepCompare(ctx, "result", "0x", "0x0000000000000000000000000000000000000000000000000000000000000000")
 	if err != nil {
 		t.Fatalf("deepCompare returned error: %v", err)
 	}
@@ -40,7 +42,7 @@ func TestDeepCompareZeroHex(t *testing.T) {
 	}
 
 	// Test the reverse order
-	diffs, err = deepCompare("result", "0x0000000000000000000000000000000000000000000000000000000000000000", "0x")
+	diffs, err = deepCompare(ctx, "result", "0x0000000000000000000000000000000000000000000000000000000000000000", "0x")
 	if err != nil {
 		t.Fatalf("deepCompare returned error: %v", err)
 	}
@@ -49,7 +51,7 @@ func TestDeepCompareZeroHex(t *testing.T) {
 	}
 
 	// Test that other hex values are still considered different
-	diffs, err = deepCompare("result", "0x1", "0x0000000000000000000000000000000000000000000000000000000000000000")
+	diffs, err = deepCompare(ctx, "result", "0x1", "0x0000000000000000000000000000000000000000000000000000000000000000")
 	if err != nil {
 		t.Fatalf("deepCompare returned error: %v", err)
 	}
@@ -73,7 +75,7 @@ func TestCompareJSONRPCResponsesZeroHex(t *testing.T) {
 	}
 
 	// Compare the responses
-	diffs, err := compareJSONRPCResponses(resp1, resp2)
+	diffs, err := compareJSONRPCResponses(nil, resp1, resp2)
 	if err != nil {
 		t.Fatalf("compareJSONRPCResponses returned error: %v", err)
 	}
@@ -81,5 +83,151 @@ func TestCompareJSONRPCResponsesZeroHex(t *testing.T) {
 	// Check that there are no differences in the result
 	if _, ok := diffs["result_differences"]; ok {
 		t.Errorf("Expected no result differences, but found some")
+	}
+}
+
+func resultResp(result interface{}) map[string]interface{} {
+	return map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": result}
+}
+
+func errorResp(code int, message string) map[string]interface{} {
+	return map[string]interface{}{"jsonrpc": "2.0", "id": 1, "error": map[string]interface{}{
+		"code": float64(code), "message": message,
+	}}
+}
+
+func hasResultDiff(diffs map[string]interface{}) bool {
+	_, ok := diffs["result_differences"]
+	return ok
+}
+
+func TestNumericTolerance(t *testing.T) {
+	rules := []ComparisonRule{{Method: "eth_estimateGas", Path: "result", Kind: RuleNumericTolerance, Abs: 32, Rel: 0.01}}
+	ctx := newDiffContext("eth_estimateGas", rules)
+
+	tests := []struct {
+		name     string
+		v1, v2   string
+		wantDiff bool
+	}{
+		{"within abs", "0x571e", "0x5720", false},                     // diff 2 <= 32
+		{"at abs boundary", "0x1000", "0x1020", false},                // diff 32 <= 32
+		{"just past abs but within rel", "0x10000", "0x10021", false}, // diff 33, rel ~0.0005
+		{"beyond both", "0x1000", "0x2000", true},                     // diff 4096, rel ~0.5
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diffs, err := deepCompare(ctx, "result", tc.v1, tc.v2)
+			if err != nil {
+				t.Fatalf("deepCompare error: %v", err)
+			}
+			if got := len(diffs) > 0; got != tc.wantDiff {
+				t.Errorf("diff=%v, want %v (diffs=%v)", got, tc.wantDiff, diffs)
+			}
+		})
+	}
+}
+
+func TestDefaultEstimateGasTolerance(t *testing.T) {
+	// No configured rules: eth_estimateGas gets the built-in 10% tolerance.
+	ctx := newDiffContext("eth_estimateGas", nil)
+
+	// 5% apart -> equal.
+	diffs, _ := deepCompare(ctx, "result", "0x64", "0x69") // 100 vs 105
+	if len(diffs) != 0 {
+		t.Errorf("expected 5%% drift within default tolerance, got %v", diffs)
+	}
+	// 20% apart -> reported.
+	diffs, _ = deepCompare(ctx, "result", "0x64", "0x78") // 100 vs 120
+	if len(diffs) == 0 {
+		t.Error("expected 20% drift to exceed default tolerance")
+	}
+
+	// A different method gets no implicit tolerance.
+	other := newDiffContext("eth_getBalance", nil)
+	diffs, _ = deepCompare(other, "result", "0x64", "0x69")
+	if len(diffs) == 0 {
+		t.Error("expected non-estimateGas method to report any difference")
+	}
+}
+
+func TestIgnorePaths(t *testing.T) {
+	rules := []ComparisonRule{
+		{Path: "result.totalDifficulty", Kind: RuleIgnore},
+		{Path: "result.transactions[*].v", Kind: RuleIgnore},
+	}
+	ctx := newDiffContext("eth_getBlockByNumber", rules)
+
+	r1 := resultResp(map[string]interface{}{
+		"number":          "0x1",
+		"totalDifficulty": nil,
+		"transactions":    []interface{}{map[string]interface{}{"v": "0x1b"}},
+	})
+	r2 := resultResp(map[string]interface{}{
+		"number":          "0x1",
+		"totalDifficulty": "0xabc",
+		"transactions":    []interface{}{map[string]interface{}{"v": "0x25"}},
+	})
+
+	diffs, err := compareJSONRPCResponses(ctx, r1, r2)
+	if err != nil {
+		t.Fatalf("compare error: %v", err)
+	}
+	if hasResultDiff(diffs) {
+		t.Errorf("ignored paths should collapse to no differences, got %v", diffs)
+	}
+
+	// Without the ignore rules the same responses differ.
+	plain := newDiffContext("eth_getBlockByNumber", nil)
+	diffs, _ = compareJSONRPCResponses(plain, r1, r2)
+	if !hasResultDiff(diffs) {
+		t.Error("expected differences without ignore rules")
+	}
+}
+
+func TestErrorCodeOnly(t *testing.T) {
+	ctx := newDiffContext("eth_call", []ComparisonRule{{Method: "eth_call", Kind: RuleErrorCodeOnly}})
+
+	// Same code, different message -> equal.
+	diffs, _ := compareJSONRPCResponses(ctx, errorResp(-32000, "insufficient funds"), errorResp(-32000, "insufficient sender balance"))
+	if _, ok := diffs["error_differences"]; ok {
+		t.Errorf("error_code_only should ignore message drift, got %v", diffs)
+	}
+
+	// Different code -> reported.
+	diffs, _ = compareJSONRPCResponses(ctx, errorResp(-32000, "x"), errorResp(-32003, "x"))
+	if _, ok := diffs["error_differences"]; !ok {
+		t.Error("expected code mismatch to be reported")
+	}
+}
+
+func TestErrorPresenceOnly(t *testing.T) {
+	ctx := newDiffContext("eth_call", []ComparisonRule{{Method: "eth_call", Kind: RuleErrorPresenceOnly}})
+	diffs, _ := compareJSONRPCResponses(ctx, errorResp(-32000, "a"), errorResp(-32602, "b"))
+	if _, ok := diffs["error_differences"]; ok {
+		t.Errorf("error_presence_only should treat any two errors as equal, got %v", diffs)
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		code int
+		msg  string
+		want string
+	}{
+		{-32601, "method not found", "namespace_disabled"},
+		{-32002, "No state available", "no_state"},
+		{-32602, "logs range too large", "range_cap"},
+		{-32602, "invalid argument", ""},
+		{-32000, "execution reverted", ""},
+	}
+	for _, tc := range tests {
+		got := classifyError(errorResp(tc.code, tc.msg))
+		if got != tc.want {
+			t.Errorf("classifyError(%d,%q)=%q want %q", tc.code, tc.msg, got, tc.want)
+		}
+	}
+	if got := classifyError(resultResp("0x1")); got != "" {
+		t.Errorf("classifyError on result response = %q, want empty", got)
 	}
 }

--- a/runner/comparator/integration_extra_test.go
+++ b/runner/comparator/integration_extra_test.go
@@ -1,0 +1,217 @@
+package comparator
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/jsonrpc-bench/runner/types"
+)
+
+func writeRPCResult(w http.ResponseWriter, id int, result interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+func decodeRPC(t *testing.T, r *http.Request) rpcRequest {
+	t.Helper()
+	body, _ := io.ReadAll(r.Body)
+	var req rpcRequest
+	_ = json.Unmarshal(body, &req)
+	return req
+}
+
+func TestCompareIntegration_RetryRecovers(t *testing.T) {
+	var mu sync.Mutex
+	attempts := map[string]int{}
+	flaky := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(t, r)
+		if req.Method == "eth_chainId" {
+			writeRPCResult(w, req.ID, "0x1")
+			return
+		}
+		mu.Lock()
+		attempts[req.Method]++
+		n := attempts[req.Method]
+		mu.Unlock()
+		if n < 2 { // fail the first attempt with a retryable 5xx
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("busy"))
+			return
+		}
+		writeRPCResult(w, req.ID, "0x123")
+	}))
+	t.Cleanup(flaky.Close)
+
+	stable := newRPCFake(t, "0x1", func(req rpcRequest) interface{} { return "0x123" })
+
+	cfg := &ComparisonConfig{
+		Name:             "retry",
+		Methods:          []string{"eth_blockNumber_variant1"},
+		MethodRPCNames:   map[string]string{"eth_blockNumber_variant1": "eth_blockNumber"},
+		CustomParameters: map[string][]interface{}{"eth_blockNumber_variant1": {}},
+		Clients: []*types.ClientConfig{
+			{Name: "flaky", URL: flaky.URL},
+			{Name: "stable", URL: stable.URL},
+		},
+		TimeoutSeconds:   5,
+		Concurrency:      1,
+		MaxRetries:       3,
+		RetryBaseDelayMs: 1,
+		OutputDir:        t.TempDir(),
+	}
+	comp, err := NewComparator(cfg)
+	if err != nil {
+		t.Fatalf("NewComparator: %v", err)
+	}
+	if _, err := comp.Run(); err != nil {
+		t.Fatalf("Run should recover after retry, got: %v", err)
+	}
+	res := comp.GetResults()[0]
+	if len(res.TransportErrors) != 0 {
+		t.Errorf("retry should have cleared transport errors, got %v", res.TransportErrors)
+	}
+	if len(res.Differences) != 0 {
+		t.Errorf("both clients returned 0x123 after retry, got diffs %v", res.Differences)
+	}
+}
+
+func TestCompareIntegration_NonFatalTransport(t *testing.T) {
+	good := newRPCFake(t, "0x1", func(req rpcRequest) interface{} {
+		if req.Method == "eth_blockNumber" {
+			return "0x5"
+		}
+		return "0xbal"
+	})
+	// partial answers chainId and eth_blockNumber but never eth_getBalance.
+	partial := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRPC(t, r)
+		switch req.Method {
+		case "eth_chainId":
+			writeRPCResult(w, req.ID, "0x1")
+		case "eth_blockNumber":
+			writeRPCResult(w, req.ID, "0x5")
+		default:
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("down"))
+		}
+	}))
+	t.Cleanup(partial.Close)
+
+	cfg := &ComparisonConfig{
+		Name: "nonfatal",
+		Methods: []string{
+			"eth_blockNumber_variant1",
+			"eth_getBalance_variant1",
+		},
+		MethodRPCNames: map[string]string{
+			"eth_blockNumber_variant1": "eth_blockNumber",
+			"eth_getBalance_variant1":  "eth_getBalance",
+		},
+		CustomParameters: map[string][]interface{}{
+			"eth_blockNumber_variant1": {},
+			"eth_getBalance_variant1":  {"0xabc", "0x1"},
+		},
+		Clients: []*types.ClientConfig{
+			{Name: "good", URL: good.URL},
+			{Name: "partial", URL: partial.URL},
+		},
+		TimeoutSeconds:   5,
+		Concurrency:      1,
+		MaxRetries:       2,
+		RetryBaseDelayMs: 1,
+		OutputDir:        t.TempDir(),
+	}
+	comp, err := NewComparator(cfg)
+	if err != nil {
+		t.Fatalf("NewComparator: %v", err)
+	}
+	if _, err := comp.Run(); err != nil {
+		t.Fatalf("a single dead call must not abort the run, got: %v", err)
+	}
+
+	byMethod := map[string]ComparisonResult{}
+	for _, r := range comp.GetResults() {
+		byMethod[r.Method] = r
+	}
+	if len(byMethod) != 2 {
+		t.Fatalf("expected both calls recorded, got %v", byMethod)
+	}
+	if got := byMethod["eth_getBalance_variant1"]; len(got.TransportErrors) == 0 {
+		t.Errorf("expected transport error recorded for the dead call, got %+v", got)
+	}
+	if got := byMethod["eth_blockNumber_variant1"]; len(got.Differences) != 0 || len(got.TransportErrors) != 0 {
+		t.Errorf("blockNumber should be clean, got %+v", got)
+	}
+	if s := comp.Summarize(); s.TransportError != 1 {
+		t.Errorf("summary transport-error = %d, want 1", s.TransportError)
+	}
+}
+
+func TestCompareIntegration_DiffOnly(t *testing.T) {
+	a := newRPCFake(t, "0x1", func(req rpcRequest) interface{} {
+		if req.Method == "eth_blockNumber" {
+			return "0x123"
+		}
+		return "0xaaa"
+	})
+	b := newRPCFake(t, "0x1", func(req rpcRequest) interface{} {
+		if req.Method == "eth_blockNumber" {
+			return "0x123"
+		}
+		return "0xbbb" // mismatch on eth_getBalance
+	})
+
+	dir := t.TempDir()
+	cfg := &ComparisonConfig{
+		Name: "diffonly",
+		Methods: []string{
+			"eth_blockNumber_variant1",
+			"eth_getBalance_variant1",
+		},
+		MethodRPCNames: map[string]string{
+			"eth_blockNumber_variant1": "eth_blockNumber",
+			"eth_getBalance_variant1":  "eth_getBalance",
+		},
+		CustomParameters: map[string][]interface{}{
+			"eth_blockNumber_variant1": {},
+			"eth_getBalance_variant1":  {"0xabc", "0x1"},
+		},
+		Clients: []*types.ClientConfig{
+			{Name: "a", URL: a.URL},
+			{Name: "b", URL: b.URL},
+		},
+		TimeoutSeconds: 5,
+		Concurrency:    1,
+		DiffOnly:       true,
+		OutputDir:      dir,
+	}
+	comp, err := NewComparator(cfg)
+	if err != nil {
+		t.Fatalf("NewComparator: %v", err)
+	}
+	if _, err := comp.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !comp.HasDifferences() {
+		t.Error("expected HasDifferences true (fail-on-diff would trip)")
+	}
+
+	jsonPath := filepath.Join(dir, "results.json")
+	if err := comp.SaveResults(jsonPath); err != nil {
+		t.Fatalf("SaveResults: %v", err)
+	}
+	data, _ := os.ReadFile(jsonPath)
+	var results []ComparisonResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(results) != 1 || results[0].Method != "eth_getBalance_variant1" {
+		t.Fatalf("--diff-only should keep only the differing call, got %d (%v)", len(results), results)
+	}
+}

--- a/runner/comparator/jsonrpc.go
+++ b/runner/comparator/jsonrpc.go
@@ -41,8 +41,11 @@ func formatCurlCommand(url string, requestJSON []byte) string {
 		string(requestJSON), url)
 }
 
-// makeJSONRPCCall makes a JSON-RPC call to the specified endpoint
-func makeJSONRPCCall(url, method string, params []interface{}, timeoutSeconds int, verbose bool) (map[string]interface{}, error) {
+// makeJSONRPCCall makes a JSON-RPC call to the specified endpoint, retrying
+// transport errors and 5xx responses with exponential backoff up to
+// maxAttempts. A 200 response carrying a JSON-RPC error object is returned as a
+// valid response (not retried); a 4xx is a hard failure (not retried).
+func makeJSONRPCCall(url, method string, params []interface{}, timeoutSeconds int, verbose bool, maxAttempts int, baseDelay time.Duration) (map[string]interface{}, error) {
 	// Create request
 	request := JSONRPCRequest{
 		JSONRPC: "2.0",
@@ -67,48 +70,65 @@ func makeJSONRPCCall(url, method string, params []interface{}, timeoutSeconds in
 		Timeout: time.Duration(timeoutSeconds) * time.Second,
 	}
 
-	// Create HTTP request
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestJSON))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	if maxAttempts < 1 {
+		maxAttempts = 1
 	}
 
-	// Set headers
-	req.Header.Set("Content-Type", "application/json")
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(backoffDelay(baseDelay, attempt))
+		}
 
-	// Send request
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("HTTP request failed: %w", err)
+		req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestJSON))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("HTTP request failed: %w", err)
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("failed to read response body: %w", err)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, string(body))
+			if resp.StatusCode >= 500 {
+				continue
+			}
+			return nil, lastErr
+		}
+
+		var rawResponse map[string]interface{}
+		if err := json.Unmarshal(body, &rawResponse); err != nil {
+			return nil, fmt.Errorf("failed to parse response: %w", err)
+		}
+		return rawResponse, nil
 	}
-	defer resp.Body.Close()
 
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
+	return nil, lastErr
+}
 
-	// Check HTTP status
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Parse response
-	var rawResponse map[string]interface{}
-	if err := json.Unmarshal(body, &rawResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	// Return raw response for comparison
-	return rawResponse, nil
+// backoffDelay returns the exponential backoff for a given (1-based) retry
+// attempt: base, 2*base, 4*base, ...
+func backoffDelay(base time.Duration, attempt int) time.Duration {
+	return base * time.Duration(1<<uint(attempt-1))
 }
 
 // BatchJSONRPCRequest represents a batch JSON-RPC request
 type BatchJSONRPCRequest []JSONRPCRequest
 
-// makeBatchJSONRPCCall makes a batch JSON-RPC call to the specified endpoint
-func makeBatchJSONRPCCall(url string, requests []JSONRPCRequest, timeoutSeconds int, verbose bool) ([]map[string]interface{}, error) {
+// makeBatchJSONRPCCall makes a batch JSON-RPC call to the specified endpoint,
+// retrying transport errors and 5xx responses with exponential backoff.
+func makeBatchJSONRPCCall(url string, requests []JSONRPCRequest, timeoutSeconds int, verbose bool, maxAttempts int, baseDelay time.Duration) ([]map[string]interface{}, error) {
 	// Marshal request to JSON
 	requestJSON, err := json.Marshal(requests)
 	if err != nil {
@@ -125,39 +145,49 @@ func makeBatchJSONRPCCall(url string, requests []JSONRPCRequest, timeoutSeconds 
 		Timeout: time.Duration(timeoutSeconds) * time.Second,
 	}
 
-	// Create HTTP request
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestJSON))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	if maxAttempts < 1 {
+		maxAttempts = 1
 	}
 
-	// Set headers
-	req.Header.Set("Content-Type", "application/json")
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(backoffDelay(baseDelay, attempt))
+		}
 
-	// Send request
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("HTTP request failed: %w", err)
+		req, err := http.NewRequest("POST", url, bytes.NewBuffer(requestJSON))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("HTTP request failed: %w", err)
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("failed to read response body: %w", err)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, string(body))
+			if resp.StatusCode >= 500 {
+				continue
+			}
+			return nil, lastErr
+		}
+
+		var rawResponses []map[string]interface{}
+		if err := json.Unmarshal(body, &rawResponses); err != nil {
+			return nil, fmt.Errorf("failed to parse batch response: %w", err)
+		}
+		return rawResponses, nil
 	}
-	defer resp.Body.Close()
 
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	// Check HTTP status
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	// Parse response
-	var rawResponses []map[string]interface{}
-	if err := json.Unmarshal(body, &rawResponses); err != nil {
-		return nil, fmt.Errorf("failed to parse batch response: %w", err)
-	}
-
-	// Return raw responses for comparison
-	return rawResponses, nil
+	return nil, lastErr
 }

--- a/runner/comparator/output_summary_test.go
+++ b/runner/comparator/output_summary_test.go
@@ -1,0 +1,114 @@
+package comparator
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2 — --diff-only drops identical calls and truncates large bodies while
+// preserving diff entries and leaving the stored results unmutated.
+func TestResultsForOutputDiffOnlyTruncates(t *testing.T) {
+	big := strings.Repeat("a", 10000)
+	c := &Comparator{
+		config: &ComparisonConfig{DiffOnly: true, MaxResponseBytes: 100},
+		results: []ComparisonResult{
+			{Method: "same"},
+			{
+				Method:      "diff",
+				Differences: map[string]interface{}{"nodeB": "changed"},
+				Responses:   map[string]interface{}{"nodeA": big, "nodeB": "small"},
+			},
+		},
+	}
+
+	out := c.resultsForOutput()
+	if len(out) != 1 || out[0].Method != "diff" {
+		t.Fatalf("diff-only should keep only the differing call, got %v", out)
+	}
+	nodeA, ok := out[0].Responses["nodeA"].(map[string]interface{})
+	if !ok || nodeA["_truncated"] != true {
+		t.Errorf("large body should be truncated, got %v", out[0].Responses["nodeA"])
+	}
+	if out[0].Responses["nodeB"] != "small" {
+		t.Errorf("small body should be kept, got %v", out[0].Responses["nodeB"])
+	}
+	if len(out[0].Differences) == 0 {
+		t.Error("diff entries must be preserved")
+	}
+	if _, ok := c.results[1].Responses["nodeA"].(string); !ok {
+		t.Error("stored results must not be mutated by resultsForOutput")
+	}
+}
+
+// #2 — the escape hatch: keeping bodies means no truncation is applied.
+func TestResultsForOutputDiffOnlyKeepBodies(t *testing.T) {
+	big := strings.Repeat("a", 10000)
+	c := &Comparator{
+		config: &ComparisonConfig{DiffOnly: true}, // no MaxResponseBytes => keep
+		results: []ComparisonResult{
+			{Method: "diff", Differences: map[string]interface{}{"n": 1}, Responses: map[string]interface{}{"nodeA": big}},
+		},
+	}
+	out := c.resultsForOutput()
+	if out[0].Responses["nodeA"] != big {
+		t.Error("without a cap, diff-only should keep full bodies")
+	}
+}
+
+// #3 — env-classified mismatches count separately and do not trip real-diff
+// gating.
+func TestSummarizeRealVsEnv(t *testing.T) {
+	c := &Comparator{
+		config: &ComparisonConfig{},
+		results: []ComparisonResult{
+			{Method: "real", Differences: map[string]interface{}{"nodeB": "x"}},
+			{Method: "env", Differences: map[string]interface{}{"nodeB": "x"}, ErrorClass: map[string]string{"nodeB": "no_state"}},
+			{Method: "same"},
+			{Method: "dead", TransportErrors: map[string]string{"nodeB": "boom"}},
+		},
+	}
+
+	s := c.Summarize()
+	if s.Differ != 1 {
+		t.Errorf("Differ (real) = %d, want 1", s.Differ)
+	}
+	if s.DifferEnv != 1 {
+		t.Errorf("DifferEnv = %d, want 1", s.DifferEnv)
+	}
+	if s.Identical != 1 {
+		t.Errorf("Identical = %d, want 1", s.Identical)
+	}
+	if s.TransportError != 1 {
+		t.Errorf("TransportError = %d, want 1", s.TransportError)
+	}
+	if s.EnvError["no_state"] != 1 {
+		t.Errorf("EnvError[no_state] = %d, want 1", s.EnvError["no_state"])
+	}
+
+	if !c.HasRealDifferences() {
+		t.Error("HasRealDifferences should be true")
+	}
+	if !c.HasEnvDifferences() {
+		t.Error("HasEnvDifferences should be true")
+	}
+}
+
+// #3 — an env-only run has no real differences, so default --fail-on-diff
+// (which gates on HasRealDifferences) must not trip.
+func TestEnvOnlyHasNoRealDifference(t *testing.T) {
+	c := &Comparator{
+		config: &ComparisonConfig{},
+		results: []ComparisonResult{
+			{Method: "env", Differences: map[string]interface{}{"nodeB": "x"}, ErrorClass: map[string]string{"nodeB": "range_cap"}},
+		},
+	}
+	if c.HasRealDifferences() {
+		t.Error("env-only run must report no real differences")
+	}
+	if !c.HasEnvDifferences() {
+		t.Error("env-only run must report env differences")
+	}
+	if s := c.Summarize(); s.Differ != 0 || s.DifferEnv != 1 {
+		t.Errorf("summary = %+v, want Differ=0 DifferEnv=1", s)
+	}
+}

--- a/runner/comparator/report.go
+++ b/runner/comparator/report.go
@@ -70,9 +70,12 @@ func formatJSON(obj interface{}) (string, error) {
 
 // GenerateHTMLReport generates an HTML report from the comparison results
 func (c *Comparator) GenerateHTMLReport(outputPath string) error {
+	// Honor the lean-output options so the report stays small.
+	results := c.resultsForOutput()
+
 	// Convert comparison results to response diffs
-	responseDiffs := make([]types.ResponseDiff, len(c.results))
-	for i, result := range c.results {
+	responseDiffs := make([]types.ResponseDiff, len(results))
+	for i, result := range results {
 		// Extract client names
 		clientNames := make([]string, 0, len(result.Responses))
 		for client := range result.Responses {

--- a/runner/comparator/rules.go
+++ b/runner/comparator/rules.go
@@ -1,0 +1,233 @@
+package comparator
+
+import (
+	"math/big"
+	"regexp"
+	"strings"
+)
+
+// ComparisonRuleKind enumerates the ways a difference can be declared expected.
+type ComparisonRuleKind string
+
+const (
+	// RuleIgnore drops a JSON path from comparison entirely.
+	RuleIgnore ComparisonRuleKind = "ignore"
+	// RuleNumericTolerance treats two hex quantities as equal when they are
+	// within an absolute and/or relative tolerance of each other.
+	RuleNumericTolerance ComparisonRuleKind = "numeric_tolerance"
+	// RuleErrorCodeOnly compares only the JSON-RPC error code, ignoring the
+	// human-readable message, when both responses are errors.
+	RuleErrorCodeOnly ComparisonRuleKind = "error_code_only"
+	// RuleErrorPresenceOnly treats any two error responses as equal.
+	RuleErrorPresenceOnly ComparisonRuleKind = "error_presence_only"
+)
+
+// ComparisonRule declares that a particular difference is expected and should
+// not be reported as a finding. A rule with an empty Method applies to every
+// method; an empty Path applies to the whole response value.
+type ComparisonRule struct {
+	Method string             `json:"method,omitempty" yaml:"method,omitempty"`
+	Path   string             `json:"path,omitempty" yaml:"path,omitempty"`
+	Kind   ComparisonRuleKind `json:"kind" yaml:"kind"`
+	Abs    float64            `json:"abs,omitempty" yaml:"abs,omitempty"`
+	Rel    float64            `json:"rel,omitempty" yaml:"rel,omitempty"`
+}
+
+// ValidRuleKind reports whether kind is one of the supported rule kinds.
+func ValidRuleKind(kind ComparisonRuleKind) bool {
+	switch kind {
+	case RuleIgnore, RuleNumericTolerance, RuleErrorCodeOnly, RuleErrorPresenceOnly:
+		return true
+	default:
+		return false
+	}
+}
+
+// defaultEstimateGasRelTolerance is applied to eth_estimateGas unless the
+// config already declares a numeric_tolerance rule for it: gas estimates that
+// differ by no more than 10% are treated as equal.
+const defaultEstimateGasRelTolerance = 0.10
+
+// diffContext carries the method under comparison and its compiled rules
+// through the recursive diff so rules can be applied by path.
+type diffContext struct {
+	method string
+	rules  *ruleSet
+}
+
+type compiledRule struct {
+	rule ComparisonRule
+	re   *regexp.Regexp
+}
+
+type ruleSet struct {
+	ignores           []compiledRule
+	tolerances        []compiledRule
+	errorCodeOnly     bool
+	errorPresenceOnly bool
+}
+
+// newDiffContext filters the config rules down to those that apply to method
+// and injects the built-in eth_estimateGas tolerance when none is configured.
+func newDiffContext(method string, rules []ComparisonRule) *diffContext {
+	applicable := make([]ComparisonRule, 0, len(rules)+1)
+	hasEstimateGasTolerance := false
+	for _, r := range rules {
+		if r.Method != "" && r.Method != method {
+			continue
+		}
+		applicable = append(applicable, r)
+		if method == "eth_estimateGas" && r.Kind == RuleNumericTolerance {
+			hasEstimateGasTolerance = true
+		}
+	}
+	if method == "eth_estimateGas" && !hasEstimateGasTolerance {
+		applicable = append(applicable, ComparisonRule{
+			Method: "eth_estimateGas",
+			Path:   "result",
+			Kind:   RuleNumericTolerance,
+			Rel:    defaultEstimateGasRelTolerance,
+		})
+	}
+	return &diffContext{method: method, rules: compileRuleSet(applicable)}
+}
+
+func compileRuleSet(rules []ComparisonRule) *ruleSet {
+	rs := &ruleSet{}
+	for _, r := range rules {
+		switch r.Kind {
+		case RuleIgnore:
+			rs.ignores = append(rs.ignores, compiledRule{rule: r, re: compileRulePath(r.Path)})
+		case RuleNumericTolerance:
+			rs.tolerances = append(rs.tolerances, compiledRule{rule: r, re: compileRulePath(r.Path)})
+		case RuleErrorCodeOnly:
+			rs.errorCodeOnly = true
+		case RuleErrorPresenceOnly:
+			rs.errorPresenceOnly = true
+		}
+	}
+	return rs
+}
+
+// compileRulePath turns a rule path into an anchored regexp. A trailing or
+// embedded "[*]" matches any array index, so "result.transactions[*].v"
+// matches "result.transactions[3].v".
+func compileRulePath(path string) *regexp.Regexp {
+	quoted := regexp.QuoteMeta(path)
+	quoted = strings.ReplaceAll(quoted, `\[\*\]`, `\[[0-9]+\]`)
+	return regexp.MustCompile("^" + quoted + "$")
+}
+
+func (rs *ruleSet) matchesIgnore(path string) bool {
+	for _, c := range rs.ignores {
+		if c.re != nil && c.re.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (rs *ruleSet) toleranceFor(path string) (ComparisonRule, bool) {
+	for _, c := range rs.tolerances {
+		if c.re != nil && c.re.MatchString(path) {
+			return c.rule, true
+		}
+	}
+	return ComparisonRule{}, false
+}
+
+// withinTolerance reports whether the rule applies to the two hex quantities
+// (applicable) and, if so, whether they are equal within tolerance (equal).
+func withinTolerance(s1, s2 string, rule ComparisonRule) (applicable, equal bool) {
+	a, ok1 := parseHexBig(s1)
+	b, ok2 := parseHexBig(s2)
+	if !ok1 || !ok2 {
+		return false, false
+	}
+
+	diff := new(big.Int).Abs(new(big.Int).Sub(a, b))
+
+	if rule.Abs > 0 {
+		absLimit := new(big.Int)
+		big.NewFloat(rule.Abs).Int(absLimit)
+		if diff.Cmp(absLimit) <= 0 {
+			return true, true
+		}
+	}
+
+	if rule.Rel > 0 {
+		absA := new(big.Float).SetInt(new(big.Int).Abs(a))
+		absB := new(big.Float).SetInt(new(big.Int).Abs(b))
+		max := absA
+		if absB.Cmp(absA) > 0 {
+			max = absB
+		}
+		if max.Sign() == 0 {
+			return true, true
+		}
+		ratio := new(big.Float).Quo(new(big.Float).SetInt(diff), max)
+		if ratio.Cmp(big.NewFloat(rule.Rel)) <= 0 {
+			return true, true
+		}
+	}
+
+	return true, false
+}
+
+// parseHexBig parses a 0x-prefixed hex quantity into a big.Int. "0x" parses
+// to zero. It returns false for non-hex strings.
+func parseHexBig(s string) (*big.Int, bool) {
+	if !strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X") {
+		return nil, false
+	}
+	digits := s[2:]
+	if digits == "" {
+		return big.NewInt(0), true
+	}
+	v, ok := new(big.Int).SetString(digits, 16)
+	if !ok {
+		return nil, false
+	}
+	return v, true
+}
+
+// errorCode extracts the numeric JSON-RPC error code from an error value.
+func errorCode(errVal interface{}) (int, bool) {
+	m, ok := errVal.(map[string]interface{})
+	if !ok {
+		return 0, false
+	}
+	code, ok := m["code"].(float64)
+	if !ok {
+		return 0, false
+	}
+	return int(code), true
+}
+
+// classifyError buckets an error response into an environment/capability class
+// so it can be filtered as configuration rather than a correctness finding.
+// It returns "" for ordinary execution errors and non-error responses.
+func classifyError(resp map[string]interface{}) string {
+	e, ok := resp["error"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	code := 0
+	if f, ok := e["code"].(float64); ok {
+		code = int(f)
+	}
+	msg, _ := e["message"].(string)
+	lower := strings.ToLower(msg)
+
+	switch code {
+	case -32601, -32600:
+		return "namespace_disabled"
+	case -32002:
+		return "no_state"
+	case -32602:
+		if strings.Contains(lower, "range") || strings.Contains(lower, "logs") || strings.Contains(lower, "limit") {
+			return "range_cap"
+		}
+	}
+	return ""
+}

--- a/runner/comparator/rules_file_test.go
+++ b/runner/comparator/rules_file_test.go
@@ -1,0 +1,120 @@
+package comparator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTempYAML chdirs into a fresh temp dir and writes a file there, returning
+// the relative name (SafeReadPath rejects absolute paths).
+func writeTempYAML(t *testing.T, name, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return name
+}
+
+func TestLoadComparisonRules_ComparisonBlock(t *testing.T) {
+	path := writeTempYAML(t, "rules.yaml", `
+comparison:
+  block_override: "0x1406f40"
+  rules:
+    - path: result.totalDifficulty
+      kind: ignore
+    - method: eth_estimateGas
+      path: result
+      kind: numeric_tolerance
+      rel: 0.1
+`)
+	rules, blockOverride, err := LoadComparisonRules(path)
+	if err != nil {
+		t.Fatalf("LoadComparisonRules: %v", err)
+	}
+	if blockOverride != "0x1406f40" {
+		t.Errorf("block override = %q, want 0x1406f40", blockOverride)
+	}
+	if len(rules) != 2 || rules[0].Kind != RuleIgnore || rules[1].Kind != RuleNumericTolerance {
+		t.Errorf("rules round-trip failed: %+v", rules)
+	}
+}
+
+func TestLoadComparisonRules_RootForm(t *testing.T) {
+	path := writeTempYAML(t, "rules.yaml", `
+block_override: "0x10"
+rules:
+  - path: result.x
+    kind: ignore
+`)
+	rules, blockOverride, err := LoadComparisonRules(path)
+	if err != nil {
+		t.Fatalf("LoadComparisonRules: %v", err)
+	}
+	if blockOverride != "0x10" || len(rules) != 1 {
+		t.Errorf("root-form round-trip failed: bo=%q rules=%d", blockOverride, len(rules))
+	}
+}
+
+func TestLoadComparisonRules_UnknownKind(t *testing.T) {
+	path := writeTempYAML(t, "rules.yaml", `
+rules:
+  - path: result
+    kind: nope
+`)
+	if _, _, err := LoadComparisonRules(path); err == nil {
+		t.Fatal("expected unknown kind error")
+	}
+}
+
+func TestLoadComparisonRules_Empty(t *testing.T) {
+	path := writeTempYAML(t, "rules.yaml", "name: irrelevant\n")
+	if _, _, err := LoadComparisonRules(path); err == nil {
+		t.Fatal("expected error for a rules file with no rules or block_override")
+	}
+}
+
+func TestMergeComparisonRulesPrepends(t *testing.T) {
+	cfg := &ComparisonConfig{Rules: []ComparisonRule{{Path: "result.a", Kind: RuleIgnore}}}
+	cfg.MergeComparisonRules([]ComparisonRule{{Path: "result.b", Kind: RuleIgnore}})
+	if len(cfg.Rules) != 2 || cfg.Rules[0].Path != "result.b" || cfg.Rules[1].Path != "result.a" {
+		t.Errorf("expected layered rule first, got %+v", cfg.Rules)
+	}
+}
+
+// TestCorpusPlusRulesCompose is the headline #1 case: a corpus run (no config
+// rules) plus a --rules file must apply those rules during comparison.
+func TestCorpusPlusRulesCompose(t *testing.T) {
+	dir := writeCorpus(t, map[string]string{
+		"c.jsonl": `{"method":"eth_getBlockByNumber","params":["0x10",false]}` + "\n",
+	})
+	cfg, err := LoadCorpusConfig(dir, 0, 42, "")
+	if err != nil {
+		t.Fatalf("LoadCorpusConfig: %v", err)
+	}
+	if len(cfg.Rules) != 0 {
+		t.Fatalf("corpus config should start with no rules, got %d", len(cfg.Rules))
+	}
+
+	cfg.MergeComparisonRules([]ComparisonRule{{Path: "result.totalDifficulty", Kind: RuleIgnore}})
+
+	ctx := newDiffContext("eth_getBlockByNumber", cfg.Rules)
+	r1 := map[string]interface{}{"result": map[string]interface{}{"number": "0x10", "totalDifficulty": nil}}
+	r2 := map[string]interface{}{"result": map[string]interface{}{"number": "0x10", "totalDifficulty": "0xabc"}}
+	diffs, err := compareJSONRPCResponses(ctx, r1, r2)
+	if err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if _, ok := diffs["result_differences"]; ok {
+		t.Errorf("merged ignore rule should suppress the totalDifficulty diff, got %v", diffs)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the `COMPARISON-IMPROVEMENTS.md` handoff brief in full, motivated by a real archive-vs-archive Nethermind correctness run (v1.39.1 vs v1.40) where three problems dominated: expected differences (e.g. `totalDifficulty`, sub-1% `eth_estimateGas` drift) flooded the report, a single transport blip discarded an 800-call run, and the report was unopenable (~769 MB HTML).

Everything is backward compatible: new config blocks and flags are optional, and defaults reproduce prior behavior aside from the additive retry.

## What's included

- **Expected-difference rules** — a unified `comparison.rules` list: `ignore` (with `[*]` array wildcards), `numeric_tolerance` (abs/rel on hex quantities), `error_code_only`, `error_presence_only`. `eth_estimateGas` gets a built-in **10% relative** tolerance by default (diffs ≤10% treated as correct).
- **Error classification** — buckets `namespace_disabled` / `no_state` / `range_cap` so capability errors are filtered as config, not correctness.
- **Retry + non-fatal transport** — bounded retry with exponential backoff for transport errors and 5xx (honors `clients.yaml` `max_retries`, plus `--max-retries` / `--retry-base-delay`); a final transport failure is recorded per-call instead of aborting the whole run.
- **Lean output** — `--diff-only`, `--omit-matching-responses`, `--max-response-bytes` gate what `comparison-results.json` and the HTML serialize.
- **Summary + CI gate** — end-of-run category tally and `--fail-on-diff` exit code.
- **Sync-gap awareness** — `--skip-above-head` skips calls pinned above the lowest client head.
- **Block pinning** — `block_override` / `--block-override` rewrites `latest`/`pending` to a static block and appends a block arg to calls that omit one.
- **Corpus helper** — `--from-jsonl` / `--sample` builds a config from `rpc-calls/*.jsonl` with deterministic sampling and proof/head-dependent/debug exclusions.
- **Provenance** — the effective config is written to a `comparison-provenance.json` sidecar and surfaced in the report.

## Files

New: `runner/comparator/{rules,block_override,corpus}.go` (+ tests). Modified: diff engine (threads a rules context), orchestrator, transport, config loader, report, and both CLI commands. Documented `comparison:` example added to `config/compare/example.yaml`.

## Testing

- `go build ./...`, `go vet ./...` clean; comparator unit + integration tests pass (tolerance boundaries, ignore `[*]`, error rules, classification, block-override rewriting, corpus sampling, retry-recovers, non-fatal transport, diff-only serialization).
- End-to-end CLI run against mock nodes: `--diff-only` kept only the real mismatch, the estimateGas drift was absorbed by the tolerance, provenance sidecar written, HTML small, `--fail-on-diff` exited non-zero.

## Notes for review

- **Gas tolerance direction**: within 10% ⇒ equal/correct; >10% ⇒ reported.
- Rules / `block_override` / `--from-jsonl` are `compare`-only (they live in the compare YAML); retry, `--diff-only`, summary, `--fail-on-diff`, `--skip-above-head` apply to both `compare` and `compare-openrpc`.
- If the baseline client (`Clients[0]`) transport-fails on a call, the reference falls back to the first client that answered.