### PR TITLE
feat: make Prometheus remote-write endpoint optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Global flags accepted by every subcommand:
 ### Basic Benchmarking
 
 ```bash
-# Run a mixed workload benchmark
+# Run a mixed workload benchmark (no Prometheus; metrics come from k6's summary.json)
 go run ./runner benchmark --config ./config/benchmark/mixed.yaml --clients ./config/clients/clients.yaml
 
 # Run a read-heavy benchmark
 go run ./runner benchmark --config ./config/benchmark/read-heavy.yaml --clients ./config/clients/clients.yaml
 
-# Run with a custom output directory and a non-default Prometheus endpoint
+# Opt into Prometheus remote-write by passing an endpoint
 go run ./runner --output ./custom-results benchmark \
   --config ./config/benchmark/mixed.yaml \
   --clients ./config/clients/clients.yaml \
@@ -169,6 +169,11 @@ go run ./runner benchmark \
   --clients ./config/clients/clients.yaml \
   --html-report
 ```
+
+`--prometheus` is optional and disabled by default. When it is omitted (or
+empty), k6 remote-write is not enabled and per-client metrics are collected from
+k6's `summary.json` instead. Passing an endpoint opts into remote-write and
+post-run PromQL queries.
 
 `benchmark` always writes `outputs/results.json` and `outputs/results.csv`.
 The HTML report at `outputs/report.html` is opt-in via `--html-report`.
@@ -391,6 +396,9 @@ clear error. The mapping is:
 
 Additional behaviour changes worth noting:
 
+- `--prometheus` is now optional and disabled by default. Omit it to run
+  without remote-write (metrics are read from k6's `summary.json`); pass an
+  endpoint to opt into Prometheus.
 - The benchmark `report.html` is opt-in via `--html-report`. JSON and CSV
   exports remain on by default.
 - The legacy `endpoints + frequency` YAML schema is no longer accepted.
@@ -477,8 +485,9 @@ For advanced time-series analysis and alerting, you can use Grafana:
 
 #### Scraping node-side metrics
 
-This tool only ships k6 client-side metrics (`k6_http_req_*`) to Prometheus.
-It does **not** scrape the Geth/Nethermind/etc. clients under test — bring
+When Prometheus is enabled, this tool only ships k6 client-side metrics
+(`k6_http_req_*`) to it. It does **not** scrape the Geth/Nethermind/etc.
+clients under test — bring
 your own observability for server-side metrics. To add them, point your own
 Prometheus at the node's metrics endpoint (each EL client publishes one):
 

--- a/rpc-calls/eth_getStorageAt-mainnet-latest.jsonl
+++ b/rpc-calls/eth_getStorageAt-mainnet-latest.jsonl
@@ -1,6 +1,5 @@
 {"method":"eth_getStorageAt","params":["0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413","0x2","latest"]}
 {"method":"eth_getStorageAt","params":["0xc1cadaffffffffffffffffffffffffffffffffff","0x0100000000000000000000000000000000000000000000000000000000000000","latest"]}
-{"method":"eth_getStorageAt","params":["0x8cED5ad0d8dA4Ec211C17355Ed3DBFEC4Cf0E5b9","0xasdf","latest"]}
 {"method":"eth_getStorageAt","params":["0x8cED5ad0d8dA4Ec211C17355Ed3DBFEC4Cf0E5b9","0x0","latest"]}
 {"method":"eth_getStorageAt","params":["0xc1cadaffffffffffffffffffffffffffffffffff","0x0100000000000000000000000000000000000000000000000000000000000000"]}
 {"method":"eth_getStorageAt","params":["0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413","0x3","latest"]}

--- a/runner/analyzer/performance_analyzer.go
+++ b/runner/analyzer/performance_analyzer.go
@@ -64,7 +64,10 @@ func (pa *PerformanceAnalyzer) calculatePerformanceScores(clients map[string]*ty
 			totalThroughput += method.Throughput
 			methodCount++
 		}
-		avgThroughput := totalThroughput / float64(methodCount)
+		var avgThroughput float64
+		if methodCount > 0 {
+			avgThroughput = totalThroughput / float64(methodCount)
+		}
 		allThroughputs = append(allThroughputs, avgThroughput)
 
 		allErrorRates = append(allErrorRates, client.ErrorRate)

--- a/runner/cmd/benchmark.go
+++ b/runner/cmd/benchmark.go
@@ -41,7 +41,7 @@ var benchmarkCmd = &cobra.Command{
 func init() {
 	benchmarkCmd.Flags().StringVar(&benchmarkConfigPath, "config", "", "Path to YAML configuration file")
 	benchmarkCmd.Flags().StringVar(&benchmarkClientsPath, "clients", "", "Path to clients configuration file (optional)")
-	benchmarkCmd.Flags().StringVar(&benchmarkPrometheusURL, "prometheus", "http://localhost:9090", "Prometheus base URL (used directly for queries; remote-write path is appended)")
+	benchmarkCmd.Flags().StringVar(&benchmarkPrometheusURL, "prometheus", "", "Prometheus base URL (optional; used directly for queries, remote-write path is appended). When empty, remote-write is disabled and metrics are collected from k6's summary.json")
 	benchmarkCmd.Flags().StringVar(&benchmarkPrometheusRWPath, "prometheus-rw-path", "/api/v1/write", "Path appended to --prometheus to form the remote-write target")
 	benchmarkCmd.Flags().StringVar(&benchmarkPrometheusRWUser, "prometheus-rw-user", "", "Prometheus basic-auth username (optional)")
 	benchmarkCmd.Flags().StringVar(&benchmarkPrometheusRWPass, "prometheus-rw-pass", "", "Prometheus basic-auth password (optional)")
@@ -55,9 +55,6 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 
 	if benchmarkConfigPath == "" {
 		return fmt.Errorf("--config is required")
-	}
-	if benchmarkPrometheusURL == "" {
-		return fmt.Errorf("--prometheus is required")
 	}
 	if benchmarkEnableHistoric && benchmarkStorageConfigPath == "" {
 		return fmt.Errorf("--storage-config is required when --historic is set")
@@ -73,20 +70,21 @@ func runBenchmark(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	queryURL := strings.TrimRight(benchmarkPrometheusURL, "/")
-	rwPath := benchmarkPrometheusRWPath
-	if !strings.HasPrefix(rwPath, "/") {
-		rwPath = "/" + rwPath
-	}
-	cfg.Outputs = &config.Outputs{
-		PrometheusRW: &config.PrometheusRW{
+	cfg.Outputs = &config.Outputs{}
+	if benchmarkPrometheusURL != "" {
+		queryURL := strings.TrimRight(benchmarkPrometheusURL, "/")
+		rwPath := benchmarkPrometheusRWPath
+		if !strings.HasPrefix(rwPath, "/") {
+			rwPath = "/" + rwPath
+		}
+		cfg.Outputs.PrometheusRW = &config.PrometheusRW{
 			Endpoint: queryURL + rwPath,
 			QueryURL: queryURL,
 			BasicAuth: config.BasicAuth{
 				Username: benchmarkPrometheusRWUser,
 				Password: benchmarkPrometheusRWPass,
 			},
-		},
+		}
 	}
 
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {

--- a/runner/generator/k6_generator.go
+++ b/runner/generator/k6_generator.go
@@ -265,7 +265,7 @@ func GenerateK6Cmd(
 
 // configureOutputs configures the outputs for the k6 command
 func configureOutputs(cfg *config.Config, cmd *exec.Cmd) *exec.Cmd {
-	if cfg.Outputs.PrometheusRW != nil {
+	if cfg.Outputs != nil && cfg.Outputs.PrometheusRW != nil {
 		cmd.Args = append(cmd.Args, "--out", "experimental-prometheus-rw")
 		cmd.Env = append(cmd.Env,
 			fmt.Sprintf("K6_PROMETHEUS_RW_SERVER_URL=%s", cfg.Outputs.PrometheusRW.Endpoint),

--- a/runner/metrics/results_collection.go
+++ b/runner/metrics/results_collection.go
@@ -19,15 +19,23 @@ import (
 )
 
 func CollectClientsMetrics(cfg *config.Config, timestamp time.Time, summaryPath string, logger *logrus.Logger) (map[string]*types.ClientMetrics, error) {
-	if cfg.Outputs.PrometheusRW != nil {
+	if cfg.Outputs != nil && cfg.Outputs.PrometheusRW != nil {
 		return collectPrometheusClientsMetrics(cfg, timestamp, summaryPath, logger)
 	}
-	return nil, fmt.Errorf("no outputs configured")
+	return collectSummaryClientsMetrics(cfg, summaryPath, logger)
 }
 
-func collectPrometheusClientsMetrics(cfg *config.Config, timestamp time.Time, summaryPath string, logger *logrus.Logger) (map[string]*types.ClientMetrics, error) {
-	clientsMetrics := make(map[string]*types.ClientMetrics, len(cfg.Calls))
+// collectSummaryClientsMetrics builds client metrics without Prometheus by
+// filling every client/method pair from k6's summary.json.
+func collectSummaryClientsMetrics(cfg *config.Config, summaryPath string, logger *logrus.Logger) (map[string]*types.ClientMetrics, error) {
+	clientsMetrics := newClientsMetricsSkeleton(cfg)
+	applySummaryFallback(clientsMetrics, cfg, summaryPath, logger)
+	finalizeClientMetrics(clientsMetrics)
+	return clientsMetrics, nil
+}
 
+func newClientsMetricsSkeleton(cfg *config.Config) map[string]*types.ClientMetrics {
+	clientsMetrics := make(map[string]*types.ClientMetrics, len(cfg.ResolvedClients))
 	for _, client := range cfg.ResolvedClients {
 		clientsMetrics[client.Name] = &types.ClientMetrics{
 			Name:              client.Name,
@@ -43,6 +51,11 @@ func collectPrometheusClientsMetrics(cfg *config.Config, timestamp time.Time, su
 			},
 		}
 	}
+	return clientsMetrics
+}
+
+func collectPrometheusClientsMetrics(cfg *config.Config, timestamp time.Time, summaryPath string, logger *logrus.Logger) (map[string]*types.ClientMetrics, error) {
+	clientsMetrics := newClientsMetricsSkeleton(cfg)
 
 	// Parse prometheus endpoint. The query API lives at the base URL; the
 	// remote-write target on cfg.Outputs.PrometheusRW.Endpoint already has
@@ -178,6 +191,15 @@ func collectPrometheusClientsMetrics(cfg *config.Config, timestamp time.Time, su
 
 	applySummaryFallback(clientsMetrics, cfg, summaryPath, logger)
 
+	finalizeClientMetrics(clientsMetrics)
+
+	return clientsMetrics, nil
+}
+
+// finalizeClientMetrics recomputes per-client totals, aggregate latency and
+// throughput from the collected per-method data, regardless of whether that
+// data came from Prometheus or the summary.json fallback.
+func finalizeClientMetrics(clientsMetrics map[string]*types.ClientMetrics) {
 	for _, client := range clientsMetrics {
 		// Recalculate totals based on method data to ensure accuracy
 		var totalRequests int64
@@ -244,8 +266,6 @@ func collectPrometheusClientsMetrics(cfg *config.Config, timestamp time.Time, su
 			}
 		}
 	}
-
-	return clientsMetrics, nil
 }
 
 func calculateStdDev(values types.MetricSummary) float64 {

--- a/runner/metrics/results_collection_test.go
+++ b/runner/metrics/results_collection_test.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"time"
+
+	"testing"
+
+	"github.com/jsonrpc-bench/runner/config"
+)
+
+func summaryForAllPairs(cfg *config.Config) map[string]k6MetricValue {
+	metrics := make(map[string]k6MetricValue)
+	for _, client := range cfg.ResolvedClients {
+		for _, call := range cfg.Calls {
+			base := "{req_name:" + call.Name + ",scenario:" + client.Name + "}"
+			metrics["http_req_duration"+base] = k6MetricValue{
+				Avg: 10, Min: 1, Max: 100, Med: 8, P90: 20, P95: 30, P99: 90,
+			}
+			metrics["http_reqs"+base] = k6MetricValue{Count: 200}
+			metrics["http_req_failed"+base] = k6MetricValue{Rate: 0.01}
+		}
+	}
+	return metrics
+}
+
+func TestCollectClientsMetrics_NoPrometheus_UsesSummary(t *testing.T) {
+	cfg := makeCfg()
+	cfg.Outputs = &config.Outputs{}
+
+	dir := t.TempDir()
+	path := writeSummary(t, dir, summaryForAllPairs(cfg))
+
+	logger, _ := makeLogger()
+	got, err := CollectClientsMetrics(cfg, time.Time{}, path, logger)
+	if err != nil {
+		t.Fatalf("CollectClientsMetrics returned error: %v", err)
+	}
+
+	for _, client := range cfg.ResolvedClients {
+		cm, ok := got[client.Name]
+		if !ok {
+			t.Fatalf("missing metrics for client %s", client.Name)
+		}
+		for _, call := range cfg.Calls {
+			method, ok := cm.Methods[call.Name]
+			if !ok {
+				t.Fatalf("missing method %s for client %s", call.Name, client.Name)
+			}
+			if method.Count != 200 || method.Avg != 10 {
+				t.Errorf("%s.%s not populated from summary: %+v", client.Name, call.Name, method)
+			}
+		}
+		wantTotal := int64(200 * len(cfg.Calls))
+		if cm.TotalRequests != wantTotal {
+			t.Errorf("%s TotalRequests = %d, want %d", client.Name, cm.TotalRequests, wantTotal)
+		}
+		if cm.Latency.Avg <= 0 {
+			t.Errorf("%s aggregate latency not finalized: %+v", client.Name, cm.Latency)
+		}
+	}
+}
+
+func TestCollectClientsMetrics_NilOutputs_UsesSummary(t *testing.T) {
+	cfg := makeCfg()
+
+	dir := t.TempDir()
+	path := writeSummary(t, dir, summaryForAllPairs(cfg))
+
+	logger, _ := makeLogger()
+	got, err := CollectClientsMetrics(cfg, time.Time{}, path, logger)
+	if err != nil {
+		t.Fatalf("CollectClientsMetrics returned error: %v", err)
+	}
+	if len(got) != len(cfg.ResolvedClients) {
+		t.Fatalf("expected %d clients, got %d", len(cfg.ResolvedClients), len(got))
+	}
+}


### PR DESCRIPTION
## Summary

The full benchmark workflow does not require a Prometheus remote-write endpoint — k6 already writes a `summary.json`, and the runner has a complete path for building per-client/per-method metrics from it. Until now the CLI forced Prometheus by defaulting `--prometheus` to `http://localhost:9090`, rejecting an empty value, and constructing `PrometheusRW` unconditionally.

This PR makes Prometheus **optional and disabled by default**.

## Behavior

| `--prometheus` value | k6 remote-write | Client metrics source |
|---|---|---|
| empty (new default) | not enabled | `summary.json` |
| a URL (opt-in) | enabled, as before | Prometheus query, `summary.json` fills gaps |

## Changes

- **`runner/cmd/benchmark.go`** — `--prometheus` defaults to empty; removed the `--prometheus is required` guard; `PrometheusRW` is only built when an endpoint is provided (`cfg.Outputs` stays non-nil).
- **`runner/metrics/results_collection.go`** — `CollectClientsMetrics` routes to a new summary-only collection path when Prometheus is not configured (instead of returning `"no outputs configured"`), filling every client/method pair from `summary.json` via the existing fallback. Extracted shared `newClientsMetricsSkeleton` and `finalizeClientMetrics` helpers so both paths behave identically after data load.
- **`runner/generator/k6_generator.go`** — defensive nil-`Outputs` guard; k6 already skipped the `experimental-prometheus-rw` output when `PrometheusRW` was nil.
- **`runner/analyzer/performance_analyzer.go`** — fix a latent `0/0 = NaN` in throughput averaging for a client with no methods. The summary-only path can now surface an empty-methods client (e.g. a node returning zero successful requests), and the `NaN` broke JSON export.
- **`README.md`** — documented Prometheus as optional/disabled-by-default across usage examples, the migration table, and the metrics section.
- **`rpc-calls/eth_getStorageAt-mainnet-latest.jsonl`** — dropped an invalid entry with a non-hex `"0xasdf"` storage slot.

## Tests / verification

- Added `runner/metrics/results_collection_test.go` covering `CollectClientsMetrics` with both nil `Outputs` and nil `PrometheusRW`, asserting metrics come from `summary.json` and totals are finalized.
- `go build`, `go vet`, and package tests pass (the pre-existing `TestP99DataFlow` requires a live PostgreSQL and is unrelated).
- Ran a real benchmark with no `--prometheus`: no required-flag error, k6 ran without remote-write, the summary.json fallback engaged, `results.json` was written, and no `NaN` in output. Opt-in run with `--prometheus http://localhost:9090` is unchanged.