### PR TITLE
feat(runner): optional seed for reproducible request sequences

### DIFF
--- a/runner/config/calls.go
+++ b/runner/config/calls.go
@@ -38,10 +38,10 @@ func (c *Call) LoadFile() error {
 	return nil
 }
 
-// Sample returns a random call from the call collection or the single call if no collection is provided
-func (c *Call) Sample() (RPCCall, error) {
+// Sample returns a call drawn uniformly from the collection with rng, or the single call if no collection is provided
+func (c *Call) Sample(rng *rand.Rand) (RPCCall, error) {
 	if len(c.Calls) > 0 {
-		return c.Calls[rand.Intn(len(c.Calls))], nil // Uniformly sample a call
+		return c.Calls[rng.Intn(len(c.Calls))], nil
 	}
 
 	// Use the single call if no collection is provided

--- a/runner/config/config.go
+++ b/runner/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	RPS             int                   `yaml:"rps"`
 	Iterations      int                   `yaml:"iterations"`
 	VUs             int                   `yaml:"vus"`
+	Seed            int64                 `yaml:"seed"` // Optional: fixes the request sequence so repeated runs replay identical requests
 	Calls           []*Call               `yaml:"calls"`
 	CallsFile       string                `yaml:"calls_file"` // Optional: use file containing RPC calls instead of generating them
 	ResolvedClients []*types.ClientConfig `yaml:"-"`

--- a/runner/config/loader.go
+++ b/runner/config/loader.go
@@ -142,6 +142,7 @@ func (cl *ConfigLoader) loadOldStyleConfig(data []byte) (*Config, error) {
 		Duration    string               `yaml:"duration"`
 		RPS         int                  `yaml:"rps"`
 		VUs         int                  `yaml:"vus"`
+		Seed        int64                `yaml:"seed"`
 		Calls       []*Call              `yaml:"calls"`
 	}
 
@@ -157,6 +158,7 @@ func (cl *ConfigLoader) loadOldStyleConfig(data []byte) (*Config, error) {
 		Duration:        oldConfig.Duration,
 		RPS:             oldConfig.RPS,
 		VUs:             oldConfig.VUs,
+		Seed:            oldConfig.Seed,
 		Calls:           oldConfig.Calls,
 		ClientRefs:      make([]string, 0, len(oldConfig.Clients)),
 		ResolvedClients: make([]*types.ClientConfig, 0, len(oldConfig.Clients)),

--- a/runner/generator/k6_generator.go
+++ b/runner/generator/k6_generator.go
@@ -193,6 +193,8 @@ func GenerateK6Requests(cfg *config.Config, outputDir string) (string, error) {
 		totalWeight += call.Weight
 	}
 
+	rng := newRNG(cfg.Seed)
+
 	// Calculate the number of requests to generate based on the duration and RPS or iterations
 	var maxRequests int
 	if cfg.RPS > 0 {
@@ -201,14 +203,14 @@ func GenerateK6Requests(cfg *config.Config, outputDir string) (string, error) {
 		maxRequests = cfg.Iterations
 	}
 	for reqsCount <= maxRequests {
-		reqRand := rand.Float64() * float64(totalWeight)
+		reqRand := rng.Float64() * float64(totalWeight)
 		cumFreq := 0.0
 		for _, call := range cfg.Calls {
 			cumFreq += float64(call.Weight)
 			if reqRand < cumFreq {
 				id := reqsCount
 
-				rpcCall, err := call.Sample()
+				rpcCall, err := call.Sample(rng)
 				if err != nil {
 					return "", fmt.Errorf("failed to sample call %s: %w", call.Name, err)
 				}
@@ -235,6 +237,15 @@ func GenerateK6Requests(cfg *config.Config, outputDir string) (string, error) {
 	writer.Flush()
 
 	return requestsPath, nil
+}
+
+// newRNG returns the generator behind request sampling: fixed by `seed` when non-zero, so two runs
+// of one config issue byte-identical request sequences; otherwise seeded from the clock.
+func newRNG(seed int64) *rand.Rand {
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+	return rand.New(rand.NewSource(seed))
 }
 
 // GenerateK6Cmd generates the k6 command and returns the command to run

--- a/runner/generator/k6_generator_test.go
+++ b/runner/generator/k6_generator_test.go
@@ -1,0 +1,44 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jsonrpc-bench/runner/config"
+)
+
+func seededRequests(t *testing.T, seed int64) string {
+	t.Helper()
+	calls := make([]config.RPCCall, 0, 50)
+	for i := 0; i < 50; i++ {
+		calls = append(calls, config.RPCCall{Method: "eth_call", Params: []interface{}{i}})
+	}
+	cfg := &config.Config{
+		Duration: "2s",
+		RPS:      100,
+		Seed:     seed,
+		Calls: []*config.Call{
+			{Name: "a", Weight: 3, Calls: calls},
+			{Name: "b", Weight: 1, Method: "eth_blockNumber", Params: []interface{}{}},
+		},
+	}
+	path, err := GenerateK6Requests(cfg, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestSeededRequestsAreReproducible(t *testing.T) {
+	if seededRequests(t, 7) != seededRequests(t, 7) {
+		t.Fatal("same seed produced different request sequences")
+	}
+	if seededRequests(t, 7) == seededRequests(t, 8) {
+		t.Fatal("different seeds produced the same request sequence")
+	}
+}


### PR DESCRIPTION
## Changes

- `seed` (int64, optional) on the benchmark config. When non-zero, request generation and file-backed call sampling draw from one `rand.Rand` seeded with it, so two runs of the same config issue byte-identical request sequences. Unset keeps the clock-seeded behaviour.
- `Call.Sample` takes the generator instead of using the global one.
- Test: same seed → identical `requests.csv`; different seed → different.

## Why

Nethermind's private-corpus eth_call A/B (`run-rpc-benchmarks.yml`, jsonbench-sweep) samples a 497-record heavy-tailed corpus with replacement; without a seed the two arms run different request mixes, which alone is ~1% noise on the mean and much more on p99. With a seed the arms are paired.

Note: `TestStorageConfigTestSuite` fails on a Windows checkout before and after this change (path handling), unrelated.